### PR TITLE
Change FastMethod.helper so that it can accurately look up methods which...

### DIFF
--- a/src/proxy/net/sf/cglib/reflect/FastMethod.java
+++ b/src/proxy/net/sf/cglib/reflect/FastMethod.java
@@ -18,6 +18,10 @@ package net.sf.cglib.reflect;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import net.sf.cglib.core.Signature;
+
+import org.objectweb.asm.Type;
+
 public class FastMethod extends FastMember
 {
     FastMethod(FastClass fc, Method method) {
@@ -25,7 +29,7 @@ public class FastMethod extends FastMember
     }
 
     private static int helper(FastClass fc, Method method) {
-        int index = fc.getIndex(method.getName(), method.getParameterTypes());
+        int index = fc.getIndex(new Signature(method.getName(), Type.getMethodDescriptor(method)));
         if (index < 0) {
             Class[] types = method.getParameterTypes();
             System.err.println("hash=" + method.getName().hashCode() + " size=" + types.length);

--- a/src/test/net/sf/cglib/reflect/TestFastClass.java
+++ b/src/test/net/sf/cglib/reflect/TestFastClass.java
@@ -589,6 +589,32 @@ public class TestFastClass extends net.sf.cglib.CodeGenTestCase {
         FastClass fc = gen.create();
     }
 
+    public void testGetMethod() throws Exception {
+      FastClass fc = FastClass.create(Base.class);
+      FastMethod method = fc.getMethod(
+          Base.class.getDeclaredMethod("foo", new Class[] { String.class }));
+      assertEquals("hello world", method.invoke(new Base(), new Object[] { "hello world" }));
+    }
+
+    class Base {
+      CharSequence foo(String f) { 
+        return f;
+      }
+    }
+
+    public void testGetMethod_covarientOverride() throws Exception {
+      FastClass fc = FastClass.create(Sub.class);
+      FastMethod method = fc.getMethod(
+          Sub.class.getDeclaredMethod("foo", new Class[] {String.class}));
+      assertEquals("foofoo", method.invoke(new Sub(), new Object[] { "foo" }));
+    }
+
+    class Sub extends Base {
+      String foo(String f) { 
+        return f + f;
+      }
+    }
+
     public TestFastClass(String testName) {
         super(testName);
     }


### PR DESCRIPTION
... are covariant overrides.

This change eliminates a 'method not found' error that could be thrown by this helper method in the case of looking up the index of a method that is a covariant override.

It may be worth deprecating FastClass.getIndex(String, Class[]) to avoid this confusing error.
