### PR TITLE
Added JDK 8 to Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
 jdk:
+  - oraclejdk8
   - openjdk7
   - openjdk6


### PR DESCRIPTION
In the end, Java 8 is the problem, so even though the build will supposedly fail it is good to have a monitor.
