### PR TITLE
Drop asm-util from the build

### DIFF
--- a/cglib/pom.xml
+++ b/cglib/pom.xml
@@ -62,10 +62,6 @@
             <artifactId>asm</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-util</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
         </dependency>

--- a/cglib/src/main/java/net/sf/cglib/transform/AbstractClassLoader.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/AbstractClassLoader.java
@@ -20,7 +20,6 @@ import net.sf.cglib.core.ClassGenerator;
 import net.sf.cglib.core.DebuggingClassWriter;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.util.*;
 import org.objectweb.asm.Attribute;
 
 import java.io.IOException;

--- a/pom.xml
+++ b/pom.xml
@@ -121,11 +121,6 @@
                 <version>5.0.3</version>
             </dependency>
             <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-util</artifactId>
-                <version>5.0.3</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
                 <version>1.9.4</version>


### PR DESCRIPTION
The only reference to asm-util in the build is a string constant in `DebuggingClassWriter` where it looks up the tracing class visitor by reflection (to handle situations when asm-util may not be on the runtime classpath):

https://github.com/cglib/cglib/blob/master/cglib/src/main/java/net/sf/cglib/core/DebuggingClassWriter.java#L41

Alternatively the asm-util dependency could be made optional in the parent pom.
