### PR TITLE
Fixed bean copier that read getters instead of setters.

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/beans/BeanCopier.java
+++ b/cglib/src/main/java/net/sf/cglib/beans/BeanCopier.java
@@ -109,7 +109,7 @@ abstract public class BeanCopier
             EmitUtils.null_constructor(ce);
             CodeEmitter e = ce.begin_method(Constants.ACC_PUBLIC, COPY, null);
             PropertyDescriptor[] getters = ReflectUtils.getBeanGetters(source);
-            PropertyDescriptor[] setters = ReflectUtils.getBeanGetters(target);
+            PropertyDescriptor[] setters = ReflectUtils.getBeanSetters(target);
 
             Map names = new HashMap();
             for (int i = 0; i < getters.length; i++) {

--- a/cglib/src/test/java/net/sf/cglib/beans/SampleGetter.java
+++ b/cglib/src/test/java/net/sf/cglib/beans/SampleGetter.java
@@ -1,0 +1,10 @@
+package net.sf.cglib.beans;
+
+public class SampleGetter {
+
+    int foo;
+
+    public int getFoo() {
+        return foo;
+    }
+}

--- a/cglib/src/test/java/net/sf/cglib/beans/SampleSetter.java
+++ b/cglib/src/test/java/net/sf/cglib/beans/SampleSetter.java
@@ -1,0 +1,10 @@
+package net.sf.cglib.beans;
+
+public class SampleSetter {
+
+    int foo;
+
+    public void setFoo(int foo) {
+        this.foo = foo;
+    }
+}

--- a/cglib/src/test/java/net/sf/cglib/beans/TestBeanCopier.java
+++ b/cglib/src/test/java/net/sf/cglib/beans/TestBeanCopier.java
@@ -34,6 +34,15 @@ public class TestBeanCopier extends TestCase {
         assertTrue(bean2.getIntP() == 42);
     }
 
+    public void testOneWay() {
+        BeanCopier copier = BeanCopier.create(SampleGetter.class, SampleSetter.class, false);
+        SampleGetter sampleGetter = new SampleGetter();
+        sampleGetter.foo = 42;
+        SampleSetter sampleSetter = new SampleSetter();
+        copier.copy(sampleGetter, sampleSetter, null);
+        assertTrue(sampleSetter.foo == 42);
+    }
+
     public void testConvert() {
         BeanCopier copier = BeanCopier.create(MA.class, MA.class, true);
         MA bean1 = new MA();
@@ -49,15 +58,15 @@ public class TestBeanCopier extends TestCase {
         });
         assertTrue(bean2.getIntP() == 43);
     }
-    
+
     public TestBeanCopier(java.lang.String testName) {
         super(testName);
     }
-    
+
     public static void main(java.lang.String[] args) {
         junit.textui.TestRunner.run(suite());
     }
-    
+
     public static Test suite() {
         return new TestSuite(TestBeanCopier.class);
     }


### PR DESCRIPTION
As reported in https://github.com/cglib/cglib/issues/29