### PR TITLE
Make test flags configurable

### DIFF
--- a/cglib/pom.xml
+++ b/cglib/pom.xml
@@ -19,17 +19,85 @@
     <packaging>jar</packaging>
 
     <!-- ====================================================================== -->
+    <!-- P R O P E R T I E S -->
+    <!-- ====================================================================== -->
+    <properties>
+        <java8.test.directory>${project.build.directory}/java8-test-classes</java8.test.directory>
+    </properties>
+
+    <!-- ====================================================================== -->
     <!-- B U I L D -->
     <!-- ====================================================================== -->
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-java8-folder</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <mkdir dir="${java8.test.directory}" />
+                            </tasks>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <source>${java.version.source}</source>
+                            <target>${java.version.target}</target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <source>${java.version.source}</source>
+                            <target>${java.version.target}</target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>java8-testCompile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                            <buildDirectory>${java8.test.directory}</buildDirectory>
+                            <compilerArgs>
+                                <arg>-parameters</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>java8-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <testClassesDirectory>${java8.test.directory}</testClassesDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/cglib/pom.xml
+++ b/cglib/pom.xml
@@ -32,24 +32,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-java8-folder</id>
-                        <phase>generate-test-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <tasks>
-                                <mkdir dir="${java8.test.directory}" />
-                            </tasks>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
                     <execution>

--- a/cglib/pom.xml
+++ b/cglib/pom.xml
@@ -19,13 +19,6 @@
     <packaging>jar</packaging>
 
     <!-- ====================================================================== -->
-    <!-- P R O P E R T I E S -->
-    <!-- ====================================================================== -->
-    <properties>
-        <java8.test.directory>${project.build.directory}/java8-test-classes</java8.test.directory>
-    </properties>
-
-    <!-- ====================================================================== -->
     <!-- B U I L D -->
     <!-- ====================================================================== -->
     <build>
@@ -33,60 +26,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <source>${java.version.source}</source>
-                            <target>${java.version.target}</target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>default-testCompile</id>
-                        <configuration>
-                            <source>${java.version.source}</source>
-                            <target>${java.version.target}</target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>java8-testCompile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                        <configuration>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                            <buildDirectory>${java8.test.directory}</buildDirectory>
-                            <compilerArgs>
-                                <arg>-parameters</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>java8-test</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <testClassesDirectory>${java8.test.directory}</testClassesDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
         </plugins>
-        
+
         <resources>
             <resource>
                 <directory>src/main/resources</directory>

--- a/cglib/src/main/java/net/sf/cglib/core/ClassEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/core/ClassEmitter.java
@@ -44,7 +44,7 @@ public class ClassEmitter extends ClassTransformer {
     }
 
     public ClassEmitter() {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
     }
 
     public void setTarget(ClassVisitor cv) {
@@ -148,7 +148,7 @@ public class ClassEmitter extends ClassTransformer {
                                          TypeUtils.toInternalNames(exceptions));
         if (sig.equals(Constants.SIG_STATIC) && !TypeUtils.isInterface(getAccess())) {
             rawStaticInit = v;
-            MethodVisitor wrapped = new MethodVisitor(Opcodes.ASM4, v) {
+            MethodVisitor wrapped = new MethodVisitor(Opcodes.ASM5, v) {
                 public void visitMaxs(int maxStack, int maxLocals) {
                     // ignore
                 }

--- a/cglib/src/main/java/net/sf/cglib/core/ClassNameReader.java
+++ b/cglib/src/main/java/net/sf/cglib/core/ClassNameReader.java
@@ -38,7 +38,7 @@ public class ClassNameReader {
     public static String[] getClassInfo(ClassReader r) {
         final List array = new ArrayList();
         try {
-            r.accept(new ClassVisitor(Opcodes.ASM4, null) {
+            r.accept(new ClassVisitor(Opcodes.ASM5, null) {
                 public void visit(int version,
                                   int access,
                                   String name,

--- a/cglib/src/main/java/net/sf/cglib/core/CodeEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/core/CodeEmitter.java
@@ -500,7 +500,8 @@ public class CodeEmitter extends LocalVariablesSorter {
         mv.visitMethodInsn(opcode,
                            type.getInternalName(),
                            sig.getName(),
-                           sig.getDescriptor());
+                           sig.getDescriptor(),
+                           opcode == Opcodes.INVOKEINTERFACE);
     }
     
     public void invoke_interface(Type owner, Signature sig) {

--- a/cglib/src/main/java/net/sf/cglib/core/DebuggingClassWriter.java
+++ b/cglib/src/main/java/net/sf/cglib/core/DebuggingClassWriter.java
@@ -46,7 +46,7 @@ public class DebuggingClassWriter extends ClassVisitor {
     }
     
     public DebuggingClassWriter(int flags) {
-	super(Opcodes.ASM4, new ClassWriter(flags));
+	super(Opcodes.ASM5, new ClassWriter(flags));
     }
 
     public void visit(int version,

--- a/cglib/src/main/java/net/sf/cglib/core/DefaultGeneratorStrategy.java
+++ b/cglib/src/main/java/net/sf/cglib/core/DefaultGeneratorStrategy.java
@@ -27,7 +27,7 @@ public class DefaultGeneratorStrategy implements GeneratorStrategy {
     }
 
     protected DebuggingClassWriter getClassVisitor() throws Exception {
-      return new DebuggingClassWriter(ClassWriter.COMPUTE_MAXS);
+      return new DebuggingClassWriter(ClassWriter.COMPUTE_FRAMES);
     }
 
     protected final ClassWriter getClassWriter() {

--- a/cglib/src/main/java/net/sf/cglib/core/LocalVariablesSorter.java
+++ b/cglib/src/main/java/net/sf/cglib/core/LocalVariablesSorter.java
@@ -63,7 +63,7 @@ public class LocalVariablesSorter extends MethodVisitor {
         final String desc,
         final MethodVisitor mv)
     {
-        super(Opcodes.ASM4, mv);
+        super(Opcodes.ASM5, mv);
         state = new State();
         Type[] args = Type.getArgumentTypes(desc);
         state.nextLocal = ((Opcodes.ACC_STATIC & access) != 0) ? 0 : 1;
@@ -74,7 +74,7 @@ public class LocalVariablesSorter extends MethodVisitor {
     }
 
     public LocalVariablesSorter(LocalVariablesSorter lvs) {
-        super(Opcodes.ASM4, lvs.mv);
+        super(Opcodes.ASM5, lvs.mv);
         state = lvs.state;
         firstLocal = lvs.firstLocal;
     }

--- a/cglib/src/main/java/net/sf/cglib/proxy/BridgeMethodResolver.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/BridgeMethodResolver.java
@@ -73,7 +73,7 @@ class BridgeMethodResolver {
         private Signature currentMethod = null;
 
         BridgedFinder(Set eligableMethods, Map resolved) {
-            super(Opcodes.ASM4);
+            super(Opcodes.ASM5);
             this.resolved = resolved;
             this.eligableMethods = eligableMethods;
         }
@@ -87,7 +87,7 @@ class BridgeMethodResolver {
             Signature sig = new Signature(name, desc);
             if (eligableMethods.remove(sig)) {
                 currentMethod = sig;
-                return new MethodVisitor(Opcodes.ASM4) {
+                return new MethodVisitor(Opcodes.ASM5) {
                     public void visitMethodInsn(int opcode, String owner, String name,
                                                 String desc) {
                         if (opcode == Opcodes.INVOKESPECIAL && currentMethod != null) {

--- a/cglib/src/main/java/net/sf/cglib/proxy/BridgeMethodResolver.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/BridgeMethodResolver.java
@@ -89,7 +89,7 @@ class BridgeMethodResolver {
                 currentMethod = sig;
                 return new MethodVisitor(Opcodes.ASM5) {
                     public void visitMethodInsn(int opcode, String owner, String name,
-                                                String desc) {
+                                                String desc, boolean itf) {
                         if (opcode == Opcodes.INVOKESPECIAL && currentMethod != null) {
                             Signature target = new Signature(name, desc);
                             // If the target signature is the same as the current,

--- a/cglib/src/main/java/net/sf/cglib/transform/AbstractClassLoader.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/AbstractClassLoader.java
@@ -86,7 +86,7 @@ abstract public class AbstractClassLoader extends ClassLoader {
 
         try {
             DebuggingClassWriter w = 
-        	    new DebuggingClassWriter(ClassWriter.COMPUTE_MAXS);
+        	    new DebuggingClassWriter(ClassWriter.COMPUTE_FRAMES);
             getGenerator(r).generateClass(w);
             byte[] b = w.toByteArray();
             Class c = super.defineClass(name, b, 0, b.length, DOMAIN);

--- a/cglib/src/main/java/net/sf/cglib/transform/AbstractClassTransformer.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/AbstractClassTransformer.java
@@ -20,7 +20,7 @@ import org.objectweb.asm.Opcodes;
 
 abstract public class AbstractClassTransformer extends ClassTransformer {
     protected AbstractClassTransformer() {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
     }
 
     public void setTarget(ClassVisitor target) {

--- a/cglib/src/main/java/net/sf/cglib/transform/AbstractTransformTask.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/AbstractTransformTask.java
@@ -84,7 +84,7 @@ abstract public class AbstractTransformTask extends AbstractProcessTask {
         ClassReader reader = getClassReader(file);
         String name[] = ClassNameReader.getClassInfo(reader);
         DebuggingClassWriter w =
-        	new DebuggingClassWriter(ClassWriter.COMPUTE_MAXS);
+        	new DebuggingClassWriter(ClassWriter.COMPUTE_FRAMES);
         ClassTransformer t = getClassTransformer(name);
         if (t != null) {
 
@@ -223,7 +223,7 @@ abstract public class AbstractTransformTask extends AbstractProcessTask {
         ClassReader reader = new ClassReader(new ByteArrayInputStream(bytes));
         String name[] = ClassNameReader.getClassInfo(reader);
         DebuggingClassWriter w =
-        	new DebuggingClassWriter(ClassWriter.COMPUTE_MAXS);
+        	new DebuggingClassWriter(ClassWriter.COMPUTE_FRAMES);
         ClassTransformer t = getClassTransformer(name);
         if (t != null) {
             if (verbose) {

--- a/cglib/src/main/java/net/sf/cglib/transform/AnnotationVisitorTee.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/AnnotationVisitorTee.java
@@ -30,7 +30,7 @@ public class AnnotationVisitorTee extends AnnotationVisitor {
     }
 
     public AnnotationVisitorTee(AnnotationVisitor av1, AnnotationVisitor av2) {
-	super(Opcodes.ASM4);
+	super(Opcodes.ASM5);
         this.av1 = av1;
         this.av2 = av2;
     }

--- a/cglib/src/main/java/net/sf/cglib/transform/ClassTransformer.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/ClassTransformer.java
@@ -20,7 +20,7 @@ import org.objectweb.asm.Opcodes;
 
 public abstract class ClassTransformer extends ClassVisitor {
     public ClassTransformer() {
-	super(Opcodes.ASM4);
+	super(Opcodes.ASM5);
     }
     public ClassTransformer(int opcode) {
 	super(opcode);

--- a/cglib/src/main/java/net/sf/cglib/transform/ClassTransformerTee.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/ClassTransformerTee.java
@@ -22,7 +22,7 @@ public class ClassTransformerTee extends ClassTransformer {
     private ClassVisitor branch;
     
     public ClassTransformerTee(ClassVisitor branch) {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
         this.branch = branch;
     }
     

--- a/cglib/src/main/java/net/sf/cglib/transform/ClassVisitorTee.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/ClassVisitorTee.java
@@ -95,4 +95,9 @@ public class ClassVisitorTee extends ClassVisitor {
         cv1.visitAttribute(attrs);
         cv2.visitAttribute(attrs);
     }
+
+    public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String desc, boolean visible) {
+        return AnnotationVisitorTee.getInstance(cv1.visitTypeAnnotation(typeRef, typePath, desc, visible),
+                                                cv2.visitTypeAnnotation(typeRef, typePath, desc, visible));
+    }
 }

--- a/cglib/src/main/java/net/sf/cglib/transform/ClassVisitorTee.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/ClassVisitorTee.java
@@ -21,7 +21,7 @@ public class ClassVisitorTee extends ClassVisitor {
     private ClassVisitor cv1, cv2;
     
     public ClassVisitorTee(ClassVisitor cv1, ClassVisitor cv2) {
-	super(Opcodes.ASM4);
+	super(Opcodes.ASM5);
 	this.cv1 = cv1;
         this.cv2 = cv2;
     }

--- a/cglib/src/main/java/net/sf/cglib/transform/FieldVisitorTee.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/FieldVisitorTee.java
@@ -19,6 +19,7 @@ import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Attribute;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.TypePath;
 
 public class FieldVisitorTee extends FieldVisitor {
     private FieldVisitor fv1, fv2;
@@ -42,6 +43,11 @@ public class FieldVisitorTee extends FieldVisitor {
     public void visitEnd() {
         fv1.visitEnd();
         fv2.visitEnd();
+    }
+
+    public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String desc, boolean visible) {
+        return AnnotationVisitorTee.getInstance(fv1.visitTypeAnnotation(typeRef, typePath, desc, visible),
+                                                fv2.visitTypeAnnotation(typeRef, typePath, desc, visible));
     }
 }
 

--- a/cglib/src/main/java/net/sf/cglib/transform/FieldVisitorTee.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/FieldVisitorTee.java
@@ -24,7 +24,7 @@ public class FieldVisitorTee extends FieldVisitor {
     private FieldVisitor fv1, fv2;
     
     public FieldVisitorTee(FieldVisitor fv1, FieldVisitor fv2) {
-	super(Opcodes.ASM4);
+	super(Opcodes.ASM5);
 	this.fv1 = fv1;
         this.fv2 = fv2;
     }

--- a/cglib/src/main/java/net/sf/cglib/transform/MethodVisitorTee.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/MethodVisitorTee.java
@@ -22,7 +22,7 @@ public class MethodVisitorTee extends MethodVisitor {
     private final MethodVisitor mv2;
     
     public MethodVisitorTee(MethodVisitor mv1, MethodVisitor mv2) {
-	super(Opcodes.ASM4);
+	super(Opcodes.ASM5);
 	this.mv1 = mv1;
         this.mv2 = mv2;
     }

--- a/cglib/src/main/java/net/sf/cglib/transform/MethodVisitorTee.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/MethodVisitorTee.java
@@ -83,7 +83,12 @@ public class MethodVisitorTee extends MethodVisitor {
         mv1.visitFieldInsn(opcode, owner, name, desc);
         mv2.visitFieldInsn(opcode, owner, name, desc);
     }
-    
+
+    public void visitMethodInsn(int opcode, String owner, String name, String desc) {
+        mv1.visitMethodInsn(opcode, owner, name, desc);
+        mv2.visitMethodInsn(opcode, owner, name, desc);
+    }
+
     public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
         mv1.visitMethodInsn(opcode, owner, name, desc, itf);
         mv2.visitMethodInsn(opcode, owner, name, desc, itf);
@@ -147,6 +152,36 @@ public class MethodVisitorTee extends MethodVisitor {
     public void visitEnd() {
         mv1.visitEnd();
         mv2.visitEnd();
+    }
+
+    public void visitParameter(String name, int access) {
+        mv1.visitParameter(name, access);
+        mv2.visitParameter(name, access);
+    }
+
+    public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String desc, boolean visible) {
+        return AnnotationVisitorTee.getInstance(mv1.visitTypeAnnotation(typeRef, typePath, desc, visible),
+                                                mv2.visitTypeAnnotation(typeRef, typePath, desc, visible));
+    }
+
+    public void visitInvokeDynamicInsn(String name, String desc, Handle bsm, Object... bsmArgs) {
+        mv1.visitInvokeDynamicInsn(name, desc, bsm, bsmArgs);
+        mv2.visitInvokeDynamicInsn(name, desc, bsm, bsmArgs);
+    }
+
+    public AnnotationVisitor visitInsnAnnotation(int typeRef, TypePath typePath, String desc, boolean visible) {
+        return AnnotationVisitorTee.getInstance(mv1.visitInsnAnnotation(typeRef, typePath, desc, visible),
+                                                mv2.visitInsnAnnotation(typeRef, typePath, desc, visible));
+    }
+
+    public AnnotationVisitor visitTryCatchAnnotation(int typeRef, TypePath typePath, String desc, boolean visible) {
+        return AnnotationVisitorTee.getInstance(mv1.visitTryCatchAnnotation(typeRef, typePath, desc, visible),
+                                                mv2.visitTryCatchAnnotation(typeRef, typePath, desc, visible));
+    }
+
+    public AnnotationVisitor visitLocalVariableAnnotation(int typeRef, TypePath typePath, Label[] start, Label[] end, int[] index, String desc, boolean visible) {
+        return AnnotationVisitorTee.getInstance(mv1.visitLocalVariableAnnotation(typeRef, typePath, start, end, index, desc, visible),
+                                                mv2.visitLocalVariableAnnotation(typeRef, typePath, start, end, index, desc, visible));
     }
 }
 

--- a/cglib/src/main/java/net/sf/cglib/transform/MethodVisitorTee.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/MethodVisitorTee.java
@@ -84,9 +84,9 @@ public class MethodVisitorTee extends MethodVisitor {
         mv2.visitFieldInsn(opcode, owner, name, desc);
     }
     
-    public void visitMethodInsn(int opcode, String owner, String name, String desc) {
-        mv1.visitMethodInsn(opcode, owner, name, desc);
-        mv2.visitMethodInsn(opcode, owner, name, desc);
+    public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+        mv1.visitMethodInsn(opcode, owner, name, desc, itf);
+        mv2.visitMethodInsn(opcode, owner, name, desc, itf);
     }
     
     public void visitJumpInsn(int opcode, Label label) {

--- a/cglib/src/main/java/net/sf/cglib/transform/impl/AddDelegateTransformer.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/impl/AddDelegateTransformer.java
@@ -75,8 +75,8 @@ public class AddDelegateTransformer extends ClassEmitterTransformer {
         if (sig.getName().equals(Constants.CONSTRUCTOR_NAME)) {
             return new CodeEmitter(e) {
                 private boolean transformInit = true;
-                public void visitMethodInsn(int opcode, String owner, String name, String desc) {
-                    super.visitMethodInsn(opcode, owner, name, desc);
+                public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+                    super.visitMethodInsn(opcode, owner, name, desc, itf);
                     if (transformInit && opcode == Constants.INVOKESPECIAL) {
                         load_this();
                         new_instance(delegateType);

--- a/cglib/src/test/java/net/sf/cglib/transform/DumpFieldsTask.java
+++ b/cglib/src/test/java/net/sf/cglib/transform/DumpFieldsTask.java
@@ -43,7 +43,7 @@ public class DumpFieldsTask extends AbstractProcessTask {
     }
 
     static class EmptyVisitor extends ClassVisitor {
-	AnnotationVisitor av = new AnnotationVisitor(Opcodes.ASM4) {
+	AnnotationVisitor av = new AnnotationVisitor(Opcodes.ASM5) {
 	    public AnnotationVisitor visitAnnotation(
 		    String name, String desc) {
 		return this;
@@ -55,7 +55,7 @@ public class DumpFieldsTask extends AbstractProcessTask {
 	};
 
 	public EmptyVisitor() {
-	    super(Opcodes.ASM4);
+	    super(Opcodes.ASM5);
 	}
 
 	public AnnotationVisitor visitAnnotation(
@@ -66,7 +66,7 @@ public class DumpFieldsTask extends AbstractProcessTask {
 	public FieldVisitor visitField(
 		int access, String name, String desc,
 		String signature, Object value) {
-	    return new FieldVisitor(Opcodes.ASM4) {
+	    return new FieldVisitor(Opcodes.ASM5) {
 		public AnnotationVisitor visitAnnotation(
 			String desc, boolean visible) {
 		    return av;
@@ -78,7 +78,7 @@ public class DumpFieldsTask extends AbstractProcessTask {
 	public MethodVisitor visitMethod(
 		int access, String name, String desc, String signature,
 		String[] exceptions) {
-	    return new MethodVisitor(Opcodes.ASM4) {
+	    return new MethodVisitor(Opcodes.ASM5) {
 		public AnnotationVisitor visitAnnotationDefault() {
 		    return av;
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
 
         <java.version.source>1.5</java.version.source>
         <java.version.target>1.5</java.version.target>
+        <java.compiler.argument />
+
+        <java.test.version.source>${java.version.source}</java.test.version.source>
+        <java.test.version.target>${java.version.target}</java.test.version.target>
+        <java.test.compiler.argument>${java.compiler.argument}</java.test.compiler.argument>
     </properties>
 
     <!-- ====================================================================== -->
@@ -73,6 +78,10 @@
                     <configuration>
                         <source>${java.version.source}</source>
                         <target>${java.version.target}</target>
+                        <compilerArgument>${java.compiler.argument}</compilerArgument>
+                        <testSource>${java.test.version.source}</testSource>
+                        <testTarget>${java.test.version.target}</testTarget>
+                        <testCompilerArgument>${java.test.compiler.argument}</testCompilerArgument>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,6 @@
         <java.version.target>1.5</java.version.target>
         <java.compiler.argument />
 
-        <java.test.version.source>${java.version.source}</java.test.version.source>
-        <java.test.version.target>${java.version.target}</java.test.version.target>
         <java.test.compiler.argument>${java.compiler.argument}</java.test.compiler.argument>
     </properties>
 
@@ -75,8 +73,6 @@
                 <jdk>[1.8,)</jdk>
             </activation>
             <properties>
-                <java.test.version.source>1.8</java.test.version.source>
-                <java.test.version.target>1.8</java.test.version.target>
                 <java.test.compiler.argument>-parameters</java.test.compiler.argument>
             </properties>
         </profile>
@@ -96,8 +92,8 @@
                         <source>${java.version.source}</source>
                         <target>${java.version.target}</target>
                         <compilerArgument>${java.compiler.argument}</compilerArgument>
-                        <testSource>${java.test.version.source}</testSource>
-                        <testTarget>${java.test.version.target}</testTarget>
+                        <testSource>${java.specification.version}</testSource>
+                        <testTarget>${java.specification.version}</testTarget>
                         <testCompilerArgument>${java.test.compiler.argument}</testCompilerArgument>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
 
         <java.version.source>1.5</java.version.source>
         <java.version.target>1.5</java.version.target>
+        <java.compiler.argument />
+
+        <java.test.version.source>${java.version.source}</java.test.version.source>
+        <java.test.version.target>${java.version.target}</java.test.version.target>
+        <java.test.compiler.argument>${java.compiler.argument}</java.test.compiler.argument>
     </properties>
 
     <!-- ====================================================================== -->
@@ -61,6 +66,23 @@
     </modules>
 
     <!-- ====================================================================== -->
+    <!-- P R O F I L E S -->
+    <!-- ====================================================================== -->
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <java.test.version.source>1.8</java.test.version.source>
+                <java.test.version.target>1.8</java.test.version.target>
+                <java.test.compiler.argument>-parameters</java.test.compiler.argument>
+            </properties>
+        </profile>
+    </profiles>
+
+    <!-- ====================================================================== -->
     <!-- B U I L D -->
     <!-- ====================================================================== -->
     <build>
@@ -68,16 +90,15 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
                         <source>${java.version.source}</source>
                         <target>${java.version.target}</target>
+                        <compilerArgument>${java.compiler.argument}</compilerArgument>
+                        <testSource>${java.test.version.source}</testSource>
+                        <testTarget>${java.test.version.target}</testTarget>
+                        <testCompilerArgument>${java.test.compiler.argument}</testCompilerArgument>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,6 @@
 
         <java.version.source>1.5</java.version.source>
         <java.version.target>1.5</java.version.target>
-        <java.compiler.argument />
-
-        <java.test.version.source>${java.version.source}</java.test.version.source>
-        <java.test.version.target>${java.version.target}</java.test.version.target>
-        <java.test.compiler.argument>${java.compiler.argument}</java.test.compiler.argument>
     </properties>
 
     <!-- ====================================================================== -->
@@ -73,15 +68,16 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>1.8</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
                         <source>${java.version.source}</source>
                         <target>${java.version.target}</target>
-                        <compilerArgument>${java.compiler.argument}</compilerArgument>
-                        <testSource>${java.test.version.source}</testSource>
-                        <testTarget>${java.test.version.target}</testTarget>
-                        <testCompilerArgument>${java.test.compiler.argument}</testCompilerArgument>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
By default this doesn't change anything, but it allows you to pass args to the build to change the language level of the test classes. For example to run the tests in Java 8 mode you would run

```
mvn clean test -Djava.test.version.source=1.8 -Djava.test.version.target=1.8
```
(this produces 5 test failures)

Or to see if the tests pass with the new Java 8 parameter name reflection flag you would run

```
mvn clean test -Djava.test.version.source=1.8 -Djava.test.version.target=1.8 -Djava.test.compiler.argument=-parameters
```
(this produces 15 test failures)

Related to issue #33, I was going to write a small Java 8 test but I figured it would be much more robust to run the entire test suite against Java 8. Unfortunately this type of testing would have to be manual, I could try making it part of the build but the result would probably be pretty nasty.