### PR TITLE
Polish exception message to avoid 'class class'.

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
@@ -454,7 +454,7 @@ public class Enhancer extends AbstractClassGenerator
         Class sc = (superclass == null) ? Object.class : superclass;
 
         if (TypeUtils.isFinal(sc.getModifiers()))
-            throw new IllegalArgumentException("Cannot subclass final class " + sc);
+            throw new IllegalArgumentException("Cannot subclass final class " + sc.getName());
         List constructors = new ArrayList(Arrays.asList(sc.getDeclaredConstructors()));
         filterConstructors(sc, constructors);
 


### PR DESCRIPTION
Polish exception message to avoid 'class class' like the following exception:

```
Caused by: java.lang.IllegalArgumentException: Cannot subclass final class class com.sun.proxy.$Proxy88
```