### PR TITLE
Fix issues with annotations and generics in transaformations

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/beans/BeanMapEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/beans/BeanMapEmitter.java
@@ -154,7 +154,7 @@ class BeanMapEmitter extends ClassEmitter {
             
     private void generateKeySet(String[] allNames) {
         // static initializer
-        declare_field(Constants.ACC_STATIC | Constants.ACC_PRIVATE, "keys", FIXED_KEY_SET, null);
+        declare_field(Constants.ACC_STATIC | Constants.ACC_PRIVATE, "keys", FIXED_KEY_SET,null, null);
 
         CodeEmitter e = begin_static();
         e.new_instance(FIXED_KEY_SET);

--- a/cglib/src/main/java/net/sf/cglib/beans/ImmutableBean.java
+++ b/cglib/src/main/java/net/sf/cglib/beans/ImmutableBean.java
@@ -80,7 +80,7 @@ public class ImmutableBean
                            null,
                            Constants.SOURCE_FILE);
 
-            ce.declare_field(Constants.ACC_FINAL | Constants.ACC_PRIVATE, FIELD_NAME, targetType, null);
+            ce.declare_field(Constants.ACC_FINAL | Constants.ACC_PRIVATE, FIELD_NAME, targetType,null, null);
 
             CodeEmitter e = ce.begin_method(Constants.ACC_PUBLIC, CSTRUCT_OBJECT, null);
             e.load_this();

--- a/cglib/src/main/java/net/sf/cglib/core/EmitUtils.java
+++ b/cglib/src/main/java/net/sf/cglib/core/EmitUtils.java
@@ -330,7 +330,7 @@ public class EmitUtils {
             // TODO: can end up with duplicated field names when using chained transformers; incorporate static hook # somehow
             String fieldName = "CGLIB$load_class$" + TypeUtils.escapeType(typeName);
             if (!ce.isFieldDeclared(fieldName)) {
-                ce.declare_field(Constants.PRIVATE_FINAL_STATIC, fieldName, Constants.TYPE_CLASS, null);
+                ce.declare_field(Constants.PRIVATE_FINAL_STATIC, fieldName, Constants.TYPE_CLASS,null, null);
                 CodeEmitter hook = ce.getStaticHook();
                 hook.push(typeName);
                 hook.invoke_static(Constants.TYPE_CLASS, FOR_NAME);
@@ -832,7 +832,7 @@ public class EmitUtils {
     public static void add_properties(ClassEmitter ce, String[] names, Type[] types) {
         for (int i = 0; i < names.length; i++) {
             String fieldName = "$cglib_prop_" + names[i];
-            ce.declare_field(Constants.ACC_PRIVATE, fieldName, types[i], null);
+            ce.declare_field(Constants.ACC_PRIVATE, fieldName, types[i],null, null);
             EmitUtils.add_property(ce, names[i], types[i], fieldName);
         }
     }

--- a/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
+++ b/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
@@ -195,6 +195,7 @@ abstract public class KeyFactory {
                 ce.declare_field(Constants.ACC_PRIVATE | Constants.ACC_FINAL,
                                  getFieldName(i),
                                  parameterTypes[i],
+                                 null,
                                  null);
                 e.dup();
                 e.load_arg(i);

--- a/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
@@ -492,18 +492,18 @@ public class Enhancer extends AbstractClassGenerator
                       Constants.SOURCE_FILE);
         List constructorInfo = CollectionUtils.transform(constructors, MethodInfoTransformer.getInstance());
 
-        e.declare_field(Constants.ACC_PRIVATE, BOUND_FIELD, Type.BOOLEAN_TYPE, null);
+        e.declare_field(Constants.ACC_PRIVATE, BOUND_FIELD, Type.BOOLEAN_TYPE, null, null);
         if (!interceptDuringConstruction) {
-            e.declare_field(Constants.ACC_PRIVATE, CONSTRUCTED_FIELD, Type.BOOLEAN_TYPE, null);
+            e.declare_field(Constants.ACC_PRIVATE, CONSTRUCTED_FIELD, Type.BOOLEAN_TYPE,null, null);
         }
-        e.declare_field(Constants.PRIVATE_FINAL_STATIC, THREAD_CALLBACKS_FIELD, THREAD_LOCAL, null);
-        e.declare_field(Constants.PRIVATE_FINAL_STATIC, STATIC_CALLBACKS_FIELD, CALLBACK_ARRAY, null);
+        e.declare_field(Constants.PRIVATE_FINAL_STATIC, THREAD_CALLBACKS_FIELD, THREAD_LOCAL,null, null);
+        e.declare_field(Constants.PRIVATE_FINAL_STATIC, STATIC_CALLBACKS_FIELD, CALLBACK_ARRAY,null, null);
         if (serialVersionUID != null) {
-            e.declare_field(Constants.PRIVATE_FINAL_STATIC, Constants.SUID_FIELD_NAME, Type.LONG_TYPE, serialVersionUID);
+            e.declare_field(Constants.PRIVATE_FINAL_STATIC, Constants.SUID_FIELD_NAME, Type.LONG_TYPE,null, serialVersionUID);
         }
 
         for (int i = 0; i < callbackTypes.length; i++) {
-            e.declare_field(Constants.ACC_PRIVATE, getCallbackField(i), callbackTypes[i], null);
+            e.declare_field(Constants.ACC_PRIVATE, getCallbackField(i), callbackTypes[i],null, null);
         }
 
         emitMethods(e, methods, actualMethods);

--- a/cglib/src/main/java/net/sf/cglib/proxy/InvocationHandlerGenerator.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/InvocationHandlerGenerator.java
@@ -37,7 +37,7 @@ implements CallbackGenerator
         for (Iterator it = methods.iterator(); it.hasNext();) {
             MethodInfo method = (MethodInfo)it.next();
             Signature impl = context.getImplSignature(method);
-            ce.declare_field(Constants.PRIVATE_FINAL_STATIC, impl.getName(), METHOD, null);
+            ce.declare_field(Constants.PRIVATE_FINAL_STATIC, impl.getName(), METHOD,null, null);
 
             CodeEmitter e = context.beginMethod(ce, method);
             Block handler = e.begin_block();

--- a/cglib/src/main/java/net/sf/cglib/proxy/LazyLoaderGenerator.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/LazyLoaderGenerator.java
@@ -53,7 +53,7 @@ class LazyLoaderGenerator implements CallbackGenerator {
             int index = ((Integer)it.next()).intValue();
 
             String delegate = "CGLIB$LAZY_LOADER_" + index;
-            ce.declare_field(Constants.ACC_PRIVATE, delegate, Constants.TYPE_OBJECT, null);
+            ce.declare_field(Constants.ACC_PRIVATE, delegate, Constants.TYPE_OBJECT,null, null);
 
             CodeEmitter e = ce.begin_method(Constants.ACC_PRIVATE |
                                             Constants.ACC_SYNCHRONIZED |

--- a/cglib/src/main/java/net/sf/cglib/proxy/MethodInterceptorGenerator.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/MethodInterceptorGenerator.java
@@ -91,9 +91,9 @@ implements CallbackGenerator
             String methodProxyField = getMethodProxyField(impl);
 
             sigMap.put(sig.toString(), methodProxyField);
-            ce.declare_field(Constants.PRIVATE_FINAL_STATIC, methodField, METHOD, null);
-            ce.declare_field(Constants.PRIVATE_FINAL_STATIC, methodProxyField, METHOD_PROXY, null);
-            ce.declare_field(Constants.PRIVATE_FINAL_STATIC, EMPTY_ARGS_NAME, Constants.TYPE_OBJECT_ARRAY, null);
+            ce.declare_field(Constants.PRIVATE_FINAL_STATIC, methodField, METHOD,null, null);
+            ce.declare_field(Constants.PRIVATE_FINAL_STATIC, methodProxyField, METHOD_PROXY,null, null);
+            ce.declare_field(Constants.PRIVATE_FINAL_STATIC, EMPTY_ARGS_NAME, Constants.TYPE_OBJECT_ARRAY,null, null);
             CodeEmitter e;
 
             // access method

--- a/cglib/src/main/java/net/sf/cglib/proxy/MixinEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/MixinEmitter.java
@@ -46,7 +46,7 @@ class MixinEmitter extends ClassEmitter {
         EmitUtils.null_constructor(this);
         EmitUtils.factory_method(this, NEW_INSTANCE);
 
-        declare_field(Constants.ACC_PRIVATE, FIELD_NAME, Constants.TYPE_OBJECT_ARRAY, null);
+        declare_field(Constants.ACC_PRIVATE, FIELD_NAME, Constants.TYPE_OBJECT_ARRAY,null, null);
 
         CodeEmitter e = begin_method(Constants.ACC_PUBLIC, CSTRUCT_OBJECT_ARRAY, null);
         e.load_this();

--- a/cglib/src/main/java/net/sf/cglib/reflect/MethodDelegate.java
+++ b/cglib/src/main/java/net/sf/cglib/reflect/MethodDelegate.java
@@ -224,7 +224,7 @@ abstract public class MethodDelegate {
                            METHOD_DELEGATE,
                            new Type[]{ Type.getType(iface) },
                            Constants.SOURCE_FILE);
-            ce.declare_field(Constants.PRIVATE_FINAL_STATIC, "eqMethod", Constants.TYPE_STRING, null);
+            ce.declare_field(Constants.PRIVATE_FINAL_STATIC, "eqMethod", Constants.TYPE_STRING,null, null);
             EmitUtils.null_constructor(ce);
 
             // generate proxied method

--- a/cglib/src/main/java/net/sf/cglib/transform/impl/AccessFieldTransformer.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/impl/AccessFieldTransformer.java
@@ -17,7 +17,9 @@ package net.sf.cglib.transform.impl;
 
 import net.sf.cglib.transform.*;
 import net.sf.cglib.core.*;
+
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Attribute;
 import org.objectweb.asm.Type;
@@ -33,8 +35,8 @@ public class AccessFieldTransformer extends ClassEmitterTransformer {
         String getPropertyName(Type owner, String fieldName);
     }
 
-    public void declare_field(int access, final String name, Type type, Object value) {
-        super.declare_field(access, name, type, value);
+    public FieldVisitor declare_field(int access, final String name, Type type,String signature, Object value) {
+       FieldVisitor visitor = super.declare_field(access, name, type,signature, value);
 
         String property = TypeUtils.upperFirst(callback.getPropertyName(getClassType(), name));
         if (property != null) {
@@ -60,5 +62,6 @@ public class AccessFieldTransformer extends ClassEmitterTransformer {
             e.return_value();
             e.end_method();
         }
+        return visitor;
     }
 }

--- a/cglib/src/main/java/net/sf/cglib/transform/impl/AddDelegateTransformer.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/impl/AddDelegateTransformer.java
@@ -46,16 +46,17 @@ public class AddDelegateTransformer extends ClassEmitterTransformer {
         }
     }
     
-    public void begin_class(int version, int access, String className, Type superType, Type[] interfaces, String sourceFile) {
+    public void begin_class(int version, int access, String className,String signature, Type superType, Type[] interfaces, String sourceFile) {
         
         if(!TypeUtils.isInterface(access)){
             
         Type[] all = TypeUtils.add(interfaces, TypeUtils.getTypes(delegateIf));
-        super.begin_class(version, access, className, superType, all, sourceFile);
+        super.begin_class(version, access, className,signature, superType, all, sourceFile);
         
         declare_field(Constants.ACC_PRIVATE | Constants.ACC_TRANSIENT,
                       DELEGATE,
                       delegateType,
+                      null,
                       null);
         for (int i = 0; i < delegateIf.length; i++) {
             Method[] methods = delegateIf[i].getMethods();
@@ -66,12 +67,12 @@ public class AddDelegateTransformer extends ClassEmitterTransformer {
             }
         }
         }else{
-           super.begin_class(version, access, className, superType, interfaces, sourceFile);
+           super.begin_class(version, access, className,signature, superType, interfaces, sourceFile);
         }
     }
 
-    public CodeEmitter begin_method(int access, Signature sig, Type[] exceptions) {
-        final CodeEmitter e = super.begin_method(access, sig, exceptions);
+    public CodeEmitter begin_method(int access, Signature sig,String signature, Type[] exceptions) {
+        final CodeEmitter e = super.begin_method(access, sig, signature, exceptions);
         if (sig.getName().equals(Constants.CONSTRUCTOR_NAME)) {
             return new CodeEmitter(e) {
                 private boolean transformInit = true;

--- a/cglib/src/main/java/net/sf/cglib/transform/impl/FieldProviderTransformer.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/impl/FieldProviderTransformer.java
@@ -16,9 +16,13 @@
 package net.sf.cglib.transform.impl;
 
 import net.sf.cglib.transform.*;
+
 import java.util.*;
+
 import net.sf.cglib.core.*;
+
 import org.objectweb.asm.Attribute;
+import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
 
@@ -47,21 +51,23 @@ public class FieldProviderTransformer extends ClassEmitterTransformer {
     private int access;
     private Map fields;
     
-    public void begin_class(int version, int access, String className, Type superType, Type[] interfaces, String sourceFile) {
+    public void begin_class(int version, int access, String className,String signature, Type superType, Type[] interfaces, String sourceFile) {
         if (!TypeUtils.isAbstract(access)) {
             interfaces = TypeUtils.add(interfaces, FIELD_PROVIDER);
         }
         this.access = access;
         fields = new HashMap();
-        super.begin_class(version, access, className, superType, interfaces, sourceFile);
+        super.begin_class(version, access, className, signature,superType, interfaces, sourceFile);
     }
 
-    public void declare_field(int access, String name, Type type, Object value) {
-        super.declare_field(access, name, type, value);
+    public FieldVisitor declare_field(int access, String name, Type type,String signature, Object value) {
+        FieldVisitor visitor = super.declare_field(access, name, type,signature, value);
         
         if (!TypeUtils.isStatic(access)) {
             fields.put(name, type);
         }
+        
+        return visitor;
     }
 
     public void end_class() {
@@ -85,8 +91,8 @@ public class FieldProviderTransformer extends ClassEmitterTransformer {
             indexes[i] = i;
         }
         
-        super.declare_field(Constants.PRIVATE_FINAL_STATIC, FIELD_NAMES, Constants.TYPE_STRING_ARRAY, null);
-        super.declare_field(Constants.PRIVATE_FINAL_STATIC, FIELD_TYPES, Constants.TYPE_CLASS_ARRAY, null);
+        super.declare_field(Constants.PRIVATE_FINAL_STATIC, FIELD_NAMES, Constants.TYPE_STRING_ARRAY,null, null);
+        super.declare_field(Constants.PRIVATE_FINAL_STATIC, FIELD_TYPES, Constants.TYPE_CLASS_ARRAY,null, null);
 
         // use separate methods here because each process switch inner class needs a final CodeEmitter
         initFieldProvider(names);

--- a/cglib/src/main/java/net/sf/cglib/transform/impl/InterceptFieldTransformer.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/impl/InterceptFieldTransformer.java
@@ -17,6 +17,8 @@ package net.sf.cglib.transform.impl;
 
 import net.sf.cglib.transform.*;
 import net.sf.cglib.core.*;
+
+import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
 
@@ -40,13 +42,14 @@ public class InterceptFieldTransformer extends ClassEmitterTransformer {
         this.filter = filter;
     }
     
-    public void begin_class(int version, int access, String className, Type superType, Type[] interfaces, String sourceFile) {
+    public void begin_class(int version, int access, String className,String signature, Type superType, Type[] interfaces, String sourceFile) {
         if (!TypeUtils.isInterface(access)) {
-            super.begin_class(version, access, className, superType, TypeUtils.add(interfaces, ENABLED), sourceFile);
+            super.begin_class(version, access, className,signature, superType, TypeUtils.add(interfaces, ENABLED), sourceFile);
                     
             super.declare_field(Constants.ACC_PRIVATE | Constants.ACC_TRANSIENT,
                                 CALLBACK_FIELD,
                                 CALLBACK,
+                                null,
                                 null);
 
             CodeEmitter e;
@@ -63,12 +66,12 @@ public class InterceptFieldTransformer extends ClassEmitterTransformer {
             e.return_value();
             e.end_method();
         } else {
-            super.begin_class(version, access, className, superType, interfaces, sourceFile);
+            super.begin_class(version, access, className,signature, superType, interfaces, sourceFile);
         }
     }
 
-    public void declare_field(int access, String name, Type type, Object value) {
-        super.declare_field(access, name, type, value);
+    public FieldVisitor declare_field(int access, String name, Type type,String signature, Object value) {
+        FieldVisitor visitor = super.declare_field(access, name, type,signature, value);
         if (!TypeUtils.isStatic(access)) {
             if (filter.acceptRead(getClassType(), name)) {
                 addReadMethod(name, type);
@@ -77,6 +80,7 @@ public class InterceptFieldTransformer extends ClassEmitterTransformer {
                 addWriteMethod(name, type);
             }
         }
+        return visitor;
     }
 
     private void addReadMethod(String name, Type type) {
@@ -138,8 +142,8 @@ public class InterceptFieldTransformer extends ClassEmitterTransformer {
         e.end_method();
     }
                 
-    public CodeEmitter begin_method(int access, Signature sig, Type[] exceptions) {
-        return new CodeEmitter(super.begin_method(access, sig, exceptions)) {
+    public CodeEmitter begin_method(int access, Signature sig,String signature, Type[] exceptions) {
+        return new CodeEmitter(super.begin_method(access, sig, signature, exceptions)) {
             public void visitFieldInsn(int opcode, String owner, String name, String desc) {
                 Type towner = TypeUtils.fromInternalName(owner);
                 switch (opcode) {

--- a/cglib/src/main/java/net/sf/cglib/transform/impl/InterceptFieldTransformer.java
+++ b/cglib/src/main/java/net/sf/cglib/transform/impl/InterceptFieldTransformer.java
@@ -26,7 +26,8 @@ import org.objectweb.asm.Type;
  * @author Juozas Baliuka, Chris Nokleberg
  */
 public class InterceptFieldTransformer extends ClassEmitterTransformer {
-    private static final String CALLBACK_FIELD = "$CGLIB_READ_WRITE_CALLBACK";
+    private static final String INIT = "<init>";
+	private static final String CALLBACK_FIELD = "$CGLIB_READ_WRITE_CALLBACK";
     private static final Type CALLBACK =
       TypeUtils.parseType("net.sf.cglib.transform.impl.InterceptFieldCallback");
     private static final Type ENABLED =
@@ -142,19 +143,19 @@ public class InterceptFieldTransformer extends ClassEmitterTransformer {
         e.end_method();
     }
                 
-    public CodeEmitter begin_method(int access, Signature sig,String signature, Type[] exceptions) {
+    public CodeEmitter begin_method(int access,final Signature sig,String signature, Type[] exceptions) {
         return new CodeEmitter(super.begin_method(access, sig, signature, exceptions)) {
             public void visitFieldInsn(int opcode, String owner, String name, String desc) {
                 Type towner = TypeUtils.fromInternalName(owner);
                 switch (opcode) {
                 case Constants.GETFIELD:
-                    if (filter.acceptRead(towner, name)) {
+                    if (filter.acceptRead(towner, name) && !sig.getName().equals(INIT)) {
                         helper(towner, readMethodSig(name, desc));
                         return;
                     }
                     break;
                 case Constants.PUTFIELD:
-                    if (filter.acceptWrite(towner, name)) {
+                    if (filter.acceptWrite(towner, name) && !sig.getName().equals(INIT)) {
                         helper(towner, writeMethodSig(name, desc));
                         return;
                     }

--- a/cglib/src/main/java/net/sf/cglib/util/ParallelSorterEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/util/ParallelSorterEmitter.java
@@ -54,7 +54,7 @@ class ParallelSorterEmitter extends ClassEmitter {
         e.super_putfield("a", Constants.TYPE_OBJECT_ARRAY);
         for (int i = 0; i < arrays.length; i++) {
             Type type = Type.getType(arrays[i].getClass());
-            declare_field(Constants.ACC_PRIVATE, getFieldName(i), type, null);
+            declare_field(Constants.ACC_PRIVATE, getFieldName(i), type, null,null);
             e.load_this();
             e.load_arg(0);
             e.push(i);

--- a/cglib/src/test/java/net/sf/cglib/transform/impl/MA.java
+++ b/cglib/src/test/java/net/sf/cglib/transform/impl/MA.java
@@ -37,11 +37,13 @@ public class MA extends Base implements Comparable<MA>{
 	}
 
 	public Long getId() {
-        return id;
+		
+		return id;
+		
     }
 
     public String getName() {
-        return name;
+        return  name;
     }
 
     public void setId(Long id) {

--- a/cglib/src/test/java/net/sf/cglib/transform/impl/MA.java
+++ b/cglib/src/test/java/net/sf/cglib/transform/impl/MA.java
@@ -1,8 +1,11 @@
 package net.sf.cglib.transform.impl;
 
 import java.io.ObjectStreamException;
+import java.util.List;
 
-public class MA extends Base{
+public class MA extends Base implements Comparable<MA>{
+	
+	@TestAnnotation
     private Long id;
     private String name;
     private String privateName;
@@ -16,8 +19,24 @@ public class MA extends Base{
     private double doubleP;
     private String stringP;
     public  String publicField;
+    
+    private List<String> list;
+    
+    private MAGeneric<? extends Number> generic;
 
-    public Long getId() {
+    public MA(MAGeneric<? extends Number> generic){
+       this.generic = generic;	
+    }
+    
+    public MA(MAType test) {
+		
+	}
+    
+    public MA() {
+		
+	}
+
+	public Long getId() {
         return id;
     }
 
@@ -116,5 +135,27 @@ public class MA extends Base{
     public void setStringP(String stringP) {
         this.stringP = stringP;
     }
+
+	public int compareTo(MA ma) {		
+		return 0;
+	}
+
+	public List<String> getList() {
+		return list;
+	}
+
+	public void setList(List<String> list) {
+		this.list = list;
+	}
+
+	public MAGeneric<? extends Number> getGeneric() {
+		return generic;
+	}
+
+	public void setGeneric(MAGeneric<? extends Number> generic) {
+		this.generic = generic;
+	}
+
+	
 }
 

--- a/cglib/src/test/java/net/sf/cglib/transform/impl/MAGeneric.java
+++ b/cglib/src/test/java/net/sf/cglib/transform/impl/MAGeneric.java
@@ -1,0 +1,5 @@
+package net.sf.cglib.transform.impl;
+
+public class MAGeneric <T extends Number>{
+
+}

--- a/cglib/src/test/java/net/sf/cglib/transform/impl/MAType.java
+++ b/cglib/src/test/java/net/sf/cglib/transform/impl/MAType.java
@@ -1,0 +1,5 @@
+package net.sf.cglib.transform.impl;
+
+public enum MAType {
+ TEST
+}

--- a/cglib/src/test/java/net/sf/cglib/transform/impl/TestAnnotation.java
+++ b/cglib/src/test/java/net/sf/cglib/transform/impl/TestAnnotation.java
@@ -1,0 +1,12 @@
+package net.sf.cglib.transform.impl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface TestAnnotation {
+
+}

--- a/cglib/src/test/java/net/sf/cglib/transform/impl/TestInterceptFields.java
+++ b/cglib/src/test/java/net/sf/cglib/transform/impl/TestInterceptFields.java
@@ -46,7 +46,9 @@ public class TestInterceptFields extends AbstractTransformTest implements  Inter
         InterceptFieldEnabled e = (InterceptFieldEnabled)this;
         e.setInterceptFieldCallback( this );
         field = "test";
-        assertEquals(TEST_VALUE,field);        
+        assertEquals(TEST_VALUE,field); 
+        //make sure constructor is valid after instrumentation  
+         new TestInterceptFields(){};
         
     }
     
@@ -61,9 +63,10 @@ public class TestInterceptFields extends AbstractTransformTest implements  Inter
                 new InterceptFieldFilter(){
                     
                     public  boolean acceptRead(Type owner, String name){
-                        return true;
+                        return  true;
                     }
                     public  boolean acceptWrite(Type owner, String name){
+                    	
                         return true;
                     }
                     

--- a/cglib/src/test/java/net/sf/cglib/transform/impl/TransformDemo.java
+++ b/cglib/src/test/java/net/sf/cglib/transform/impl/TransformDemo.java
@@ -19,212 +19,220 @@ package net.sf.cglib.transform.impl;
 import net.sf.cglib.transform.*;
 import net.sf.cglib.core.*;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.*;
+
+import javax.management.RuntimeErrorException;
 
 /**
  *
  * @author  baliuka
  */
 public class TransformDemo {
-    
-    public static void register(Class cls){
-      System.out.println("register " + cls);
-    }
-    
-   
-    public static void start(){
-     
-        MA ma = new MA();
-        makePersistent(ma);
-        ma.setCharP('A');
-        ma.getCharP();
-        ma.setDoubleP(554);
-        ma.setDoubleP(1.2);
-        ma.getFloatP();
-        ma.setName("testName");
-        ma.publicField = "set value";
-        ma.publicField = ma.publicField + " append value";
-        ma.setBaseTest("base test field");
-        ma.getBaseTest();
-    
-    }
-    
-    public static void makePersistent(Object obj){
-        System.out.println( "makePersistent " + obj.getClass() + " " +  Arrays.asList(obj.getClass().getInterfaces()) ); 
-        InterceptFieldEnabled t = (InterceptFieldEnabled)obj;
-        t.setInterceptFieldCallback( new StateManager());
-        FieldProvider provider = (FieldProvider)obj;
-        System.out.println("Field Names " + Arrays.asList(provider.getFieldNames()) );
-        System.out.println("Field Types " + Arrays.asList(provider.getFieldTypes()) );
-        PersistenceCapable pc = (PersistenceCapable)obj;
-        pc.setPersistenceManager("Manager");
-    
-    }
-    
-    public static void main( String args [] )throws Exception{
-    
-     ClassTransformerFactory transformation =  
-     
-        new ClassTransformerFactory (){
-        
-           public ClassTransformer newInstance(){
-            try{       
-              InterceptFieldTransformer t1 = new InterceptFieldTransformer( new Filter() );
-        
-        
-              AddStaticInitTransformer t2 = new   AddStaticInitTransformer(
-                TransformDemo.class.getMethod("register",new Class[]{Class.class}) 
-              );                                   
-        
-        
-              AddDelegateTransformer t3 = new AddDelegateTransformer(
-                          new Class[]{PersistenceCapable.class},
-                          PersistenceCapableImpl.class
-                    );    
-                          
-              FieldProviderTransformer t4 = new FieldProviderTransformer();                 
-        
-              return new ClassTransformerChain( new ClassTransformer[]{t4,t1,t2,t3} );
-              
-            }catch(Exception e){
-              throw new CodeGenerationException(e);
-            } 
-           }  
-    };
-        
-        TransformingClassLoader loader = new TransformingClassLoader(
-          TransformDemo.class.getClassLoader(),
-          new ClassFilter(){
-            public boolean accept(String name){
-                System.out.println("load : "  + name);
-                boolean f =
-                  Base.class.getName().equals(name) ||  
-                  MA.class.getName().equals(name) || 
-                     TransformDemo.class.getName().equals(name);
-                if(f){
-                 System.out.println("transforming " + name);
-                }
-                return f;
-            } 
-         },
-         transformation
-        );
-        
-        
-        loader.loadClass(TransformDemo.class.getName()).getMethod("start",new Class[]{}).invoke(null, (Object[])null);
-    
-    }
-    
-    
-   public static class Filter implements InterceptFieldFilter{
-       
-        
-        public boolean acceptRead(org.objectweb.asm.Type owner, String name) {
-                  return true;
-        }
-        
-        public boolean acceptWrite(org.objectweb.asm.Type owner, String name) {
-                  return true;
-        }
-        
-    };
-    
 
-  public   static class  StateManager implements InterceptFieldCallback{
-        
-       
-        public boolean readBoolean(Object _this, String name, boolean oldValue) {
-            System.out.println("read " +  name + " = " + oldValue);
-            return oldValue;
-        }        
-       
-        public byte readByte(Object _this, String name, byte oldValue) {
-            System.out.println("read " +  name + " = " + oldValue);
-            return oldValue;
-        }
-        
-        public char readChar(Object _this, String name, char oldValue) {
-            System.out.println("read " +  name + " = " + oldValue);
-            return oldValue;
-        }
-        
-        public double readDouble(Object _this, String name, double oldValue) {
-            System.out.println("read " +  name + " = " + oldValue);
-            return oldValue;
-        }
-        
-        public float readFloat(Object _this, String name, float oldValue) {
-            System.out.println("read " +  name + " = " + oldValue);
-            return oldValue;
-        }
-        
-        public int readInt(Object _this, String name, int oldValue) {
-            System.out.println("read " +  name + " = " + oldValue);
-            return oldValue;
-        }
-        
-        public long readLong(Object _this, String name, long oldValue) {
-            System.out.println("read " +  name + " = " + oldValue);
-            return oldValue;
-        }
-        
-        public Object readObject(Object _this, String name, Object oldValue) {
-            System.out.println("read " +  name + " = " + oldValue);
-            return oldValue;
-        }
-        
-        public short readShort(Object _this, String name, short oldValue) {
-            System.out.println("read " +  name + " = " + oldValue);
-            return oldValue;
-        }
-        
-        public boolean writeBoolean(Object _this, String name, boolean oldValue, boolean newValue) {
-            System.out.println( "write " + name + " = " + newValue);
-            return newValue;
-        }
-        
-        public byte writeByte(Object _this, String name, byte oldValue, byte newValue) {
-            System.out.println( "write " + name + " = " + newValue);
-            return newValue;
-        }
-        
-        public char writeChar(Object _this, String name, char oldValue, char newValue) {
-            System.out.println( "write " + name + " = " + newValue);
-            return newValue;
-        }
-        
-        public double writeDouble(Object _this, String name, double oldValue, double newValue) {
-            System.out.println( "write " + name + " = " + newValue);
-            return newValue;
-        }
-        
-        public float writeFloat(Object _this, String name, float oldValue, float newValue) {
-            System.out.println( "write " + name + " = " + newValue);
-            return newValue;
-        }
-        
-        public int writeInt(Object _this, String name, int oldValue, int newValue) {
-            System.out.println( "write " + name + " = " + newValue);
-            return newValue;
-        }
-        
-        public long writeLong(Object _this, String name, long oldValue, long newValue) {
-            System.out.println( "write " + name + " = " + newValue);
-            return newValue;
-        }
-        
-        public Object writeObject(Object _this, String name, Object oldValue, Object newValue) {
-            System.out.println( "write " + name + " = " + newValue);
-            return newValue;
-        }
-        
-        public short writeShort(Object _this, String name, short oldValue, short newValue) {
-            System.out.println( "write " + name + " = " + newValue);
-            return newValue;
-        }
-        
-       }
+	public static void register(Class cls){
+		System.out.println("register " + cls);
+	}
 
-    
-    
+
+	public static void start() throws NoSuchMethodException, SecurityException, NoSuchFieldException, ClassNotFoundException{
+
+		MA ma = new MA();
+		makePersistent(ma);
+		ma.setCharP('A');
+		ma.getCharP();
+		ma.setDoubleP(554);
+		ma.setDoubleP(1.2);
+		ma.getFloatP();
+		ma.setName("testName");
+		ma.publicField = "set value";
+		ma.publicField = ma.publicField + " append value";
+		ma.setBaseTest("base test field");
+		ma.getBaseTest();
+		
+
+	}
+
+	public static void makePersistent(Object obj){
+		System.out.println( "makePersistent " + obj.getClass() + " " +  Arrays.asList(obj.getClass().getInterfaces()) ); 
+		InterceptFieldEnabled t = (InterceptFieldEnabled)obj;
+		t.setInterceptFieldCallback( new StateManager());
+		FieldProvider provider = (FieldProvider)obj;
+		System.out.println("Field Names " + Arrays.asList(provider.getFieldNames()) );
+		System.out.println("Field Types " + Arrays.asList(provider.getFieldTypes()) );
+		PersistenceCapable pc = (PersistenceCapable)obj;
+		pc.setPersistenceManager("Manager");
+
+	}
+
+	public static void main( String args [] )throws Exception{
+
+		ClassTransformerFactory transformation =  
+
+				new ClassTransformerFactory (){
+
+			public ClassTransformer newInstance(){
+				try{       
+					InterceptFieldTransformer t1 = new InterceptFieldTransformer( new Filter() );
+
+
+					AddStaticInitTransformer t2 = new   AddStaticInitTransformer(
+							TransformDemo.class.getMethod("register",new Class[]{Class.class}) 
+							);                                   
+
+
+					AddDelegateTransformer t3 = new AddDelegateTransformer(
+							new Class[]{PersistenceCapable.class},
+							PersistenceCapableImpl.class
+							);    
+
+					FieldProviderTransformer t4 = new FieldProviderTransformer();                 
+
+					return new ClassTransformerChain( new ClassTransformer[]{t4,t1,t2,t3} );
+
+				}catch(Exception e){
+					throw new CodeGenerationException(e);
+				} 
+			}  
+		};
+
+		TransformingClassLoader loader = new TransformingClassLoader(
+				TransformDemo.class.getClassLoader(),
+				new ClassFilter(){
+					public boolean accept(String name){
+						System.out.println("load : "  + name);
+						boolean f =
+								Base.class.getName().equals(name) ||  
+								MA.class.getName().equals(name) ||
+								MAGeneric.class.getName().equals(name) ||
+								MAType.class.getName().equals(name) || 
+								TransformDemo.class.getName().equals(name);
+						if(f){
+							System.out.println("transforming " + name);
+						}
+						return f;
+					} 
+				},
+				transformation
+				);
+
+
+		loader.loadClass(TransformDemo.class.getName()).getMethod("start",new Class[]{}).invoke(null, (Object[])null);
+
+	}
+
+
+	public static class Filter implements InterceptFieldFilter{
+
+
+		public boolean acceptRead(org.objectweb.asm.Type owner, String name) {
+			return true;
+		}
+
+		public boolean acceptWrite(org.objectweb.asm.Type owner, String name) {
+			return true;
+		}
+
+	};
+
+
+	public   static class  StateManager implements InterceptFieldCallback{
+
+
+		public boolean readBoolean(Object _this, String name, boolean oldValue) {
+			System.out.println("read " +  name + " = " + oldValue);
+			return oldValue;
+		}        
+
+		public byte readByte(Object _this, String name, byte oldValue) {
+			System.out.println("read " +  name + " = " + oldValue);
+			return oldValue;
+		}
+
+		public char readChar(Object _this, String name, char oldValue) {
+			System.out.println("read " +  name + " = " + oldValue);
+			return oldValue;
+		}
+
+		public double readDouble(Object _this, String name, double oldValue) {
+			System.out.println("read " +  name + " = " + oldValue);
+			return oldValue;
+		}
+
+		public float readFloat(Object _this, String name, float oldValue) {
+			System.out.println("read " +  name + " = " + oldValue);
+			return oldValue;
+		}
+
+		public int readInt(Object _this, String name, int oldValue) {
+			System.out.println("read " +  name + " = " + oldValue);
+			return oldValue;
+		}
+
+		public long readLong(Object _this, String name, long oldValue) {
+			System.out.println("read " +  name + " = " + oldValue);
+			return oldValue;
+		}
+
+		public Object readObject(Object _this, String name, Object oldValue) {
+			System.out.println("read " +  name + " = " + oldValue);
+			return oldValue;
+		}
+
+		public short readShort(Object _this, String name, short oldValue) {
+			System.out.println("read " +  name + " = " + oldValue);
+			return oldValue;
+		}
+
+		public boolean writeBoolean(Object _this, String name, boolean oldValue, boolean newValue) {
+			System.out.println( "write " + name + " = " + newValue);
+			return newValue;
+		}
+
+		public byte writeByte(Object _this, String name, byte oldValue, byte newValue) {
+			System.out.println( "write " + name + " = " + newValue);
+			return newValue;
+		}
+
+		public char writeChar(Object _this, String name, char oldValue, char newValue) {
+			System.out.println( "write " + name + " = " + newValue);
+			return newValue;
+		}
+
+		public double writeDouble(Object _this, String name, double oldValue, double newValue) {
+			System.out.println( "write " + name + " = " + newValue);
+			return newValue;
+		}
+
+		public float writeFloat(Object _this, String name, float oldValue, float newValue) {
+			System.out.println( "write " + name + " = " + newValue);
+			return newValue;
+		}
+
+		public int writeInt(Object _this, String name, int oldValue, int newValue) {
+			System.out.println( "write " + name + " = " + newValue);
+			return newValue;
+		}
+
+		public long writeLong(Object _this, String name, long oldValue, long newValue) {
+			System.out.println( "write " + name + " = " + newValue);
+			return newValue;
+		}
+
+		public Object writeObject(Object _this, String name, Object oldValue, Object newValue) {
+			System.out.println( "write " + name + " = " + newValue);
+			return newValue;
+		}
+
+		public short writeShort(Object _this, String name, short oldValue, short newValue) {
+			System.out.println( "write " + name + " = " + newValue);
+			return newValue;
+		}
+
+	}
+
+
+
 }

--- a/cglib/src/test/java/net/sf/cglib/transform/impl/TransformDemo.java
+++ b/cglib/src/test/java/net/sf/cglib/transform/impl/TransformDemo.java
@@ -40,13 +40,14 @@ public class TransformDemo {
 	public static void start() throws NoSuchMethodException, SecurityException, NoSuchFieldException, ClassNotFoundException{
 
 		MA ma = new MA();
-		makePersistent(ma);
+		makePersistent(ma);		
 		ma.setCharP('A');
 		ma.getCharP();
 		ma.setDoubleP(554);
 		ma.setDoubleP(1.2);
 		ma.getFloatP();
 		ma.setName("testName");
+		ma.getName();
 		ma.publicField = "set value";
 		ma.publicField = ma.publicField + " append value";
 		ma.setBaseTest("base test field");
@@ -105,7 +106,7 @@ public class TransformDemo {
 						System.out.println("load : "  + name);
 						boolean f =
 								Base.class.getName().equals(name) ||  
-								MA.class.getName().equals(name) ||
+								name.startsWith(MA.class.getName()) ||
 								MAGeneric.class.getName().equals(name) ||
 								MAType.class.getName().equals(name) || 
 								TransformDemo.class.getName().equals(name);


### PR DESCRIPTION
This change should fix issues related to byte code instrumentation on Java 5 and above, it is used by Hibernate 3.x http://in.relation.to/2010/08/19/deprecated-cglib-support/ and impacts many legacy applications 
 