### PR TITLE
Fix a few issues in VisibilityPredicate that prevent FastClass from generating accessors for protected methods

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/VisibilityPredicate.java
+++ b/cglib/src/main/java/net/sf/cglib/core/VisibilityPredicate.java
@@ -21,22 +21,31 @@ import org.objectweb.asm.Type;
 public class VisibilityPredicate implements Predicate {
     private boolean protectedOk;
     private String pkg;
+    private boolean samePackageOk;
 
     public VisibilityPredicate(Class source, boolean protectedOk) {
         this.protectedOk = protectedOk;
+        // same package is not ok for the bootstrap loaded classes.  In all other cases we are 
+        // generating classes in the same classloader
+        this.samePackageOk = source.getClassLoader() != null;
         pkg = TypeUtils.getPackageName(Type.getType(source));
     }
 
     public boolean evaluate(Object arg) {
-        int mod = (arg instanceof Member) ? ((Member)arg).getModifiers() : ((Integer)arg).intValue();
+        Member member = (Member)arg;
+		int mod = member.getModifiers();
         if (Modifier.isPrivate(mod)) {
             return false;
         } else if (Modifier.isPublic(mod)) {
             return true;
-        } else if (Modifier.isProtected(mod)) {
-            return protectedOk;
+        } else if (Modifier.isProtected(mod) && protectedOk) {
+            // protected is fine if 'protectedOk' is true (for subclasses)
+            return true;
         } else {
-            return pkg.equals(TypeUtils.getPackageName(Type.getType(((Member)arg).getDeclaringClass())));
+            // protected/package private if the member is in the same package as the source class 
+            // and we are generating into the same classloader.
+            return samePackageOk 
+                && pkg.equals(TypeUtils.getPackageName(Type.getType(member.getDeclaringClass())));
         }
     }
 }


### PR DESCRIPTION
There were 2 issues here

VisibilityPredicate would assume that default acceess
(package-private) was always fine as long as the member in question
was in the same package as the generated type.  In fact it needs to
also be in the same classloader.  This is normally a non-issue since
cglib tries to generate types into the types classloader.  The main
time this doesn't work is for classes on the bootstrap classpath (jdk
types).  So this adds a specific workaround for that.

VisibilityPredicate also assumed that protected access restricted
visibility to subtypes only, this is too strict, protected members are
also visible to types in the same package.

This should ultimately allow guice to drop some !protected checks in a
few places.

A super corrected fix would have VisibilityPredicate take the 'target' 
classloader as a parameter.  But im not sure how 'public' these apis are
and whether or not it would be safe to change them.