### PR TITLE
Avoid PermGen leak

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/beans/ImmutableBean.java
+++ b/cglib/src/main/java/net/sf/cglib/beans/ImmutableBean.java
@@ -70,6 +70,11 @@ public class ImmutableBean
             return super.create(name);
         }
 
+        @Override
+        protected String flattenKey(Object key) {
+            return (String) key;
+        }
+
         public void generateClass(ClassVisitor v) {
             Type targetType = Type.getType(target);
             ClassEmitter ce = new ClassEmitter(v);

--- a/cglib/src/main/java/net/sf/cglib/core/AbstractClassGenerator.java
+++ b/cglib/src/main/java/net/sf/cglib/core/AbstractClassGenerator.java
@@ -64,11 +64,11 @@ implements ClassGenerator
 
     final protected String getClassName() {
         if (className == null)
-            className = getClassName(getClassLoader());
+            className = getClassName(getClassLoader(), key);
         return className;
     }
 
-    private String getClassName(final ClassLoader loader) {
+    private String getClassName(final ClassLoader loader, Object key) {
         final Set nameCache = getClassNameCache(loader);
         return namingPolicy.getClassName(namePrefix, source.name, key, new Predicate() {
             public boolean evaluate(Object arg) {
@@ -211,7 +211,7 @@ implements ClassGenerator
                     cache2.put(NAME_KEY, new HashSet());
                     source.cache.put(loader, cache2);
                 } else if (useCache) {
-                    Reference ref = (Reference)cache2.get(key);
+                    Reference ref = (Reference) cache2.get(flattenKey(key));
                     gen = (Class) (( ref == null ) ? null : ref.get()); 
                 }
                 if (gen == null) {
@@ -239,7 +239,7 @@ implements ClassGenerator
                         }
                        
                         if (useCache) {
-                            cache2.put(key, new WeakReference(gen));
+                            cache2.put(flattenKey(key), new WeakReference(gen));
                         }
                         return firstInstance(gen);
                     } finally {
@@ -255,6 +255,20 @@ implements ClassGenerator
         } catch (Exception e) {
             throw new CodeGenerationException(e);
         }
+    }
+
+    /**
+     * Most key implementations hold references to the callbacks of the
+     * generated class that may hold references to whatever the callback needs
+     * to work. Those references in the callback being referenced by the key
+     * would prevent those classes from being unloaded and its ClassLoader
+     * garbage collected.
+     * <p/>
+     * By flattening the key to a string representation and not using it for
+     * anything else these unwanted references are kept away from the cache.
+     */
+    protected String flattenKey(Object key) {
+        return getClassName(getClassLoader(), key);
     }
 
     abstract protected Object firstInstance(Class type) throws Exception;

--- a/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
+++ b/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
@@ -149,6 +149,11 @@ abstract public class KeyFactory {
             return (KeyFactory)super.create(keyInterface.getName());
         }
 
+        @Override
+        protected String flattenKey(Object key) {
+            return (String) key;
+        }
+
         public void setHashConstant(int constant) {
             this.constant = constant;
         }

--- a/cglib/src/main/java/net/sf/cglib/proxy/InterfaceMaker.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/InterfaceMaker.java
@@ -86,6 +86,11 @@ public class InterfaceMaker extends AbstractClassGenerator
         return (Class)super.create(this);
     }
 
+    @Override
+    protected String flattenKey(Object key) {
+        return key.toString();
+    }
+
     protected ClassLoader getDefaultClassLoader() {
         return null;
     }

--- a/cglib/src/main/java/net/sf/cglib/reflect/FastClass.java
+++ b/cglib/src/main/java/net/sf/cglib/reflect/FastClass.java
@@ -65,6 +65,11 @@ abstract public class FastClass
             return (FastClass)super.create(type.getName());
         }
 
+        @Override
+        protected String flattenKey(Object key) {
+            return (String) key;
+        }
+
         protected ClassLoader getDefaultClassLoader() {
             return type.getClassLoader();
         }

--- a/cglib/src/main/java/net/sf/cglib/reflect/MulticastDelegate.java
+++ b/cglib/src/main/java/net/sf/cglib/reflect/MulticastDelegate.java
@@ -98,6 +98,11 @@ abstract public class MulticastDelegate implements Cloneable {
             return (MulticastDelegate)super.create(iface.getName());
         }
 
+        @Override
+        protected String flattenKey(Object key) {
+            return (String) key;
+        }
+
         public void generateClass(ClassVisitor cv) {
             final MethodInfo method = ReflectUtils.getMethodInfo(ReflectUtils.findInterfaceMethod(iface));
 

--- a/cglib/src/test/java/net/sf/cglib/TestGenerator.java
+++ b/cglib/src/test/java/net/sf/cglib/TestGenerator.java
@@ -40,4 +40,9 @@ abstract public class TestGenerator extends AbstractClassGenerator {
     public Object create() {
         return create(new Integer(counter++));
     }
+
+    @Override
+    protected String flattenKey(Object key) {
+        return Integer.toString((Integer) key);
+    }
 }


### PR DESCRIPTION
The key object put in the cache may be an instance of a dynamically generated class that references an application classloader. That reference causes said classloader to not be available for garbage collection, thus leaking the PermGen with old classes when that classloader is not needed anymore. This is mostly experienced in application restart scenarios, where each application has its own classloader managed in a long-lived container.

Attached is an exceprt from a heap dump that shoes the reference to the classloader that causes the issue:

![screen shot 2015-11-10 at 11 00 50 am](https://cloud.githubusercontent.com/assets/8010105/11064311/3a39b5ea-879b-11e5-8449-88ea4d06bdff.png)
