### PR TITLE
Fix permgen leak by storing Class instances as String

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/ClassesKey.java
+++ b/cglib/src/main/java/net/sf/cglib/core/ClassesKey.java
@@ -16,7 +16,7 @@
 package net.sf.cglib.core;
 
 public class ClassesKey {
-    private static final Key FACTORY = (Key)KeyFactory.create(Key.class, KeyFactory.OBJECT_BY_CLASS);
+    private static final Key FACTORY = (Key)KeyFactory.create(Key.class);
     
     interface Key {
         Object newInstance(Object[] array);
@@ -26,6 +26,21 @@ public class ClassesKey {
     }
 
     public static Object create(Object[] array) {
-        return FACTORY.newInstance(array);
+        return FACTORY.newInstance(classNames(array));
+    }
+
+    private static String[] classNames(Object[] objects) {
+        if (objects == null) {
+            return null;
+        }
+        String[] classNames = new String[objects.length];
+        for (int i = 0; i < objects.length; i++) {
+            Object object = objects[i];
+            if (object != null) {
+                Class<?> aClass = object.getClass();
+                classNames[i] = aClass == null ? null : aClass.getName();
+            }
+        }
+        return classNames;
     }
 }

--- a/cglib/src/main/java/net/sf/cglib/core/Constants.java
+++ b/cglib/src/main/java/net/sf/cglib/core/Constants.java
@@ -53,7 +53,8 @@ public interface Constants extends org.objectweb.asm.Opcodes {
     public static final Type TYPE_ERROR = TypeUtils.parseType("Error");
     public static final Type TYPE_SYSTEM = TypeUtils.parseType("System");
     public static final Type TYPE_SIGNATURE = TypeUtils.parseType("net.sf.cglib.core.Signature");
-    
+    public static final Type TYPE_TYPE = Type.getType(Type.class);
+
     public static final String CONSTRUCTOR_NAME = "<init>";
     public static final String STATIC_NAME = "<clinit>";
     public static final String SOURCE_FILE = "<generated>";

--- a/cglib/src/main/java/net/sf/cglib/core/Customizer.java
+++ b/cglib/src/main/java/net/sf/cglib/core/Customizer.java
@@ -17,6 +17,12 @@ package net.sf.cglib.core;
 
 import org.objectweb.asm.Type;
 
-public interface Customizer {
+/**
+ * Customizes key types for {@link KeyFactory} when building equals, hashCode, and toString.
+ * For customization of field types, use {@link FieldTypeCustomizer}
+ *
+ * @see KeyFactory#CLASS_BY_NAME
+ */
+public interface Customizer extends KeyFactoryCustomizer {
     void customize(CodeEmitter e, Type type);
 }

--- a/cglib/src/main/java/net/sf/cglib/core/DefaultNamingPolicy.java
+++ b/cglib/src/main/java/net/sf/cglib/core/DefaultNamingPolicy.java
@@ -29,6 +29,11 @@ import java.util.Set;
  */
 public class DefaultNamingPolicy implements NamingPolicy {
     public static final DefaultNamingPolicy INSTANCE = new DefaultNamingPolicy();
+
+    /**
+     * This allows to test collisions of {@code key.hashCode()}.
+     */
+    private final static boolean STRESS_HASH_CODE = Boolean.getBoolean("net.sf.cglib.test.stressHashCodes");
     
     public String getClassName(String prefix, String source, Object key, Predicate names) {
         if (prefix == null) {
@@ -40,7 +45,7 @@ public class DefaultNamingPolicy implements NamingPolicy {
             prefix + "$$" + 
             source.substring(source.lastIndexOf('.') + 1) +
             getTag() + "$$" +
-            Integer.toHexString(key.hashCode());
+            Integer.toHexString(STRESS_HASH_CODE ? 0 : key.hashCode());
         String attempt = base;
         int index = 2;
         while (names.evaluate(attempt))

--- a/cglib/src/main/java/net/sf/cglib/core/FieldTypeCustomizer.java
+++ b/cglib/src/main/java/net/sf/cglib/core/FieldTypeCustomizer.java
@@ -1,0 +1,23 @@
+package net.sf.cglib.core;
+
+import org.objectweb.asm.Type;
+
+/**
+ * Customizes key types for {@link KeyFactory} right in constructor.
+ */
+public interface FieldTypeCustomizer extends KeyFactoryCustomizer {
+    /**
+     * Customizes {@code this.FIELD_0 = ?} assignment in key constructor
+     * @param e code emitter
+     * @param index parameter index
+     * @param type parameter type
+     */
+    void customize(CodeEmitter e, int index, Type type);
+
+    /**
+     * Computes type of field for storing given parameter
+     * @param index parameter index
+     * @param type parameter type
+     */
+    Type getOutType(int index, Type type);
+}

--- a/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
+++ b/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
@@ -16,11 +16,15 @@
 
 package net.sf.cglib.core;
 
-import java.lang.reflect.Method;
-import java.security.ProtectionDomain;
+import net.sf.cglib.core.internal.CustomizerRegistry;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
+
+import java.lang.reflect.Method;
+import java.security.ProtectionDomain;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Generates classes to handle multi-valued keys, for use in things such as Maps and Sets.
@@ -66,7 +70,9 @@ abstract public class KeyFactory {
       TypeUtils.parseSignature("StringBuffer append(String)");
     private static final Type KEY_FACTORY =
       TypeUtils.parseType("net.sf.cglib.core.KeyFactory");
-    
+    private static final Signature GET_SORT =
+      TypeUtils.parseSignature("int getSort()");
+
     //generated numbers: 
     private final static int PRIMES[] = {
                11,         73,        179,       331,
@@ -92,6 +98,26 @@ abstract public class KeyFactory {
         }
     };
 
+    public static final FieldTypeCustomizer STORE_CLASS_AS_STRING = new FieldTypeCustomizer() {
+        public void customize(CodeEmitter e, int index, Type type) {
+            if (type.equals(Constants.TYPE_CLASS)) {
+                e.invoke_virtual(Constants.TYPE_CLASS, GET_NAME);
+            }
+        }
+
+        public Type getOutType(int index, Type type) {
+            if (type.equals(Constants.TYPE_CLASS)) {
+                return Constants.TYPE_STRING;
+            }
+            return type;
+        }
+    };
+
+    /**
+     * @deprecated this customizer might result in unexpected class leak since key object still holds a strong reference to the Object and class.
+     *             It is recommended to have pre-processing method that would strip Objects and represent Classes as Strings
+     */
+    @Deprecated
     public static final Customizer OBJECT_BY_CLASS = new Customizer() {
         public void customize(CodeEmitter e, Type type) {
             e.invoke_virtual(Constants.TYPE_OBJECT, GET_CLASS);
@@ -109,18 +135,37 @@ abstract public class KeyFactory {
         return create(keyInterface.getClassLoader(), keyInterface,  customizer);
     }
 
+    public static KeyFactory create(Class keyInterface, KeyFactoryCustomizer first, List<KeyFactoryCustomizer> next) {
+        return create(keyInterface.getClassLoader(), keyInterface, first, next);
+    }
+
     public static KeyFactory create(ClassLoader loader, Class keyInterface, Customizer customizer) {
+        return create(loader, keyInterface, customizer, Collections.<KeyFactoryCustomizer>emptyList());
+    }
+
+    public static KeyFactory create(ClassLoader loader, Class keyInterface, KeyFactoryCustomizer customizer,
+                                    List<KeyFactoryCustomizer> next) {
         Generator gen = new Generator();
         gen.setInterface(keyInterface);
-        gen.setCustomizer(customizer);
+
+        if (customizer != null) {
+            gen.addCustomizer(customizer);
+        }
+        if (next != null && !next.isEmpty()) {
+            for (KeyFactoryCustomizer keyFactoryCustomizer : next) {
+                gen.addCustomizer(keyFactoryCustomizer);
+            }
+        }
         gen.setClassLoader(loader);
         return gen.create();
     }
 
     public static class Generator extends AbstractClassGenerator {
         private static final Source SOURCE = new Source(KeyFactory.class.getName());
+        private static final Class[] KNOWN_CUSTOMIZER_TYPES = new Class[]{Customizer.class, FieldTypeCustomizer.class};
+
         private Class keyInterface;
-        private Customizer customizer;
+        private final CustomizerRegistry customizers = new CustomizerRegistry(KNOWN_CUSTOMIZER_TYPES);
         private int constant;
         private int multiplier;
 
@@ -136,8 +181,12 @@ abstract public class KeyFactory {
         	return ReflectUtils.getProtectionDomain(keyInterface);
         }
 
-        public void setCustomizer(Customizer customizer) {
-            this.customizer = customizer;
+        public void addCustomizer(KeyFactoryCustomizer customizer) {
+            customizers.add(customizer);
+        }
+
+        public <T> List<T> getCustomizers(Class<T> klass) {
+            return customizers.get(klass);
         }
 
         public void setInterface(Class keyInterface) {
@@ -190,14 +239,23 @@ abstract public class KeyFactory {
             e.load_this();
             e.super_invoke_constructor();
             e.load_this();
+            List<FieldTypeCustomizer> fieldTypeCustomizers = getCustomizers(FieldTypeCustomizer.class);
             for (int i = 0; i < parameterTypes.length; i++) {
-                seed += parameterTypes[i].hashCode();
+                Type parameterType = parameterTypes[i];
+                Type fieldType = parameterType;
+                for (FieldTypeCustomizer customizer : fieldTypeCustomizers) {
+                    fieldType = customizer.getOutType(i, fieldType);
+                }
+                seed += fieldType.hashCode();
                 ce.declare_field(Constants.ACC_PRIVATE | Constants.ACC_FINAL,
                                  getFieldName(i),
-                                 parameterTypes[i],
+                                 fieldType,
                                  null);
                 e.dup();
                 e.load_arg(i);
+                for (FieldTypeCustomizer customizer : fieldTypeCustomizers) {
+                    customizer.customize(e, i, parameterType);
+                }
                 e.putfield(getFieldName(i));
             }
             e.return_value();
@@ -211,7 +269,7 @@ abstract public class KeyFactory {
             for (int i = 0; i < parameterTypes.length; i++) {
                 e.load_this();
                 e.getfield(getFieldName(i));
-                EmitUtils.hash_code(e, parameterTypes[i], hm, customizer);
+                EmitUtils.hash_code(e, parameterTypes[i], hm, customizers);
             }
             e.return_value();
             e.end_method();
@@ -228,7 +286,7 @@ abstract public class KeyFactory {
                 e.load_arg(0);
                 e.checkcast_this();
                 e.getfield(getFieldName(i));
-                EmitUtils.not_equals(e, parameterTypes[i], fail, customizer);
+                EmitUtils.not_equals(e, parameterTypes[i], fail, customizers);
             }
             e.push(1);
             e.return_value();
@@ -249,7 +307,7 @@ abstract public class KeyFactory {
                 }
                 e.load_this();
                 e.getfield(getFieldName(i));
-                EmitUtils.append_string(e, parameterTypes[i], EmitUtils.DEFAULT_DELIMITERS, customizer);
+                EmitUtils.append_string(e, parameterTypes[i], EmitUtils.DEFAULT_DELIMITERS, customizers);
             }
             e.invoke_virtual(Constants.TYPE_STRING_BUFFER, TO_STRING);
             e.return_value();

--- a/cglib/src/main/java/net/sf/cglib/core/KeyFactoryCustomizer.java
+++ b/cglib/src/main/java/net/sf/cglib/core/KeyFactoryCustomizer.java
@@ -1,0 +1,7 @@
+package net.sf.cglib.core;
+
+/**
+ * Marker interface for customizers of {@link KeyFactory}
+ */
+public interface KeyFactoryCustomizer {
+}

--- a/cglib/src/main/java/net/sf/cglib/core/WeakIdentityKey.java
+++ b/cglib/src/main/java/net/sf/cglib/core/WeakIdentityKey.java
@@ -1,0 +1,40 @@
+package net.sf.cglib.core;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Allows to check for reference identity, yet the class does not keep strong reference to the target.
+ * {@link #equals(Object)} returns true if and only if the reference is not yet expired and other
+ * object is referencing exactly the same object.
+ *
+ * @param <T> type of the reference
+ */
+public class WeakIdentityKey<T> extends WeakReference<T> {
+    private final int hash;
+
+    public WeakIdentityKey(T referent) {
+        super(referent);
+        this.hash = System.identityHashCode(referent);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof WeakIdentityKey)) {
+            return false;
+        }
+        Object ours = get();
+        Object theirs = ((WeakIdentityKey) obj).get();
+        return ours == theirs && ours != null;
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        T t = get();
+        return t == null ? "Clean WeakIdentityKey, hash: " + hash : t.toString();
+    }
+}

--- a/cglib/src/main/java/net/sf/cglib/core/internal/CustomizerRegistry.java
+++ b/cglib/src/main/java/net/sf/cglib/core/internal/CustomizerRegistry.java
@@ -1,0 +1,35 @@
+package net.sf.cglib.core.internal;
+
+import net.sf.cglib.core.KeyFactoryCustomizer;
+
+import java.util.*;
+
+public class CustomizerRegistry {
+    private final Class[] customizerTypes;
+    private Map<Class, List<KeyFactoryCustomizer>> customizers = new HashMap<Class, List<KeyFactoryCustomizer>>();
+
+    public CustomizerRegistry(Class[] customizerTypes) {
+        this.customizerTypes = customizerTypes;
+    }
+
+    public void add(KeyFactoryCustomizer customizer) {
+        Class<? extends KeyFactoryCustomizer> klass = customizer.getClass();
+        for (Class type : customizerTypes) {
+            if (type.isAssignableFrom(klass)) {
+                List<KeyFactoryCustomizer> list = customizers.get(type);
+                if (list == null) {
+                    customizers.put(type, list = new ArrayList<KeyFactoryCustomizer>());
+                }
+                list.add(customizer);
+            }
+        }
+    }
+
+    public <T> List<T> get(Class<T> klass) {
+        List<KeyFactoryCustomizer> list = customizers.get(klass);
+        if (list == null) {
+            return Collections.emptyList();
+        }
+        return (List<T>) list;
+    }
+}

--- a/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
@@ -15,13 +15,11 @@
  */
 package net.sf.cglib.proxy;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.ProtectionDomain;
 import java.util.*;
 import net.sf.cglib.core.*;
-import org.objectweb.asm.Attribute;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.Label;
@@ -124,7 +122,7 @@ public class Enhancer extends AbstractClassGenerator
     public interface EnhancerKey {
         public Object newInstance(String type,
                                   String[] interfaces,
-                                  CallbackFilter filter,
+                                  WeakIdentityKey<CallbackFilter> filter,
                                   Type[] callbackTypes,
                                   boolean useFactory,
                                   boolean interceptDuringConstruction,
@@ -377,7 +375,7 @@ public class Enhancer extends AbstractClassGenerator
         }
         return super.create(KEY_FACTORY.newInstance((superclass != null) ? superclass.getName() : null,
                                                     ReflectUtils.getNames(interfaces),
-                                                    filter,
+                                                    filter == ALL_ZERO ? null : new WeakIdentityKey<CallbackFilter>(filter),
                                                     callbackTypes,
                                                     useFactory,
                                                     interceptDuringConstruction,

--- a/cglib/src/test/java/net/sf/cglib/beans/TestBeanMap.java
+++ b/cglib/src/test/java/net/sf/cglib/beans/TestBeanMap.java
@@ -23,6 +23,10 @@ import java.util.*;
 import junit.framework.*;
 
 public class TestBeanMap extends net.sf.cglib.CodeGenTestCase {
+    public static class TestBean2 {
+        private String foo;
+    }
+
     public static class TestBean {
         private String foo;
         private String bar = "x";
@@ -67,6 +71,14 @@ public class TestBeanMap extends net.sf.cglib.CodeGenTestCase {
     public void testBeanMap() {
         TestBean bean = new TestBean();
         BeanMap map = BeanMap.create(bean);
+        BeanMap map2 = BeanMap.create(bean);
+        assertEquals("BeanMap.create should use exactly the same bean class when called multiple times",
+                map.getClass(), map2.getClass()
+        );
+        BeanMap map3 = BeanMap.create(new TestBean2());
+        assertNotSame("BeanMap.create should use different classes for different beans",
+                map.getClass(), map3.getClass()
+        );
         assertTrue(map.size() == 6);
         assertTrue(map.get("foo") == null);
         map.put("foo", "FOO");

--- a/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
@@ -15,7 +15,11 @@
  */
 package net.sf.cglib.proxy;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -27,6 +31,7 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import net.sf.cglib.CodeGenTestCase;
+import net.sf.cglib.core.AbstractClassGenerator;
 import net.sf.cglib.core.DefaultNamingPolicy;
 import net.sf.cglib.core.ReflectUtils;
 import net.sf.cglib.reflect.FastClass;
@@ -241,6 +246,87 @@ public class TestEnhancer extends CodeGenTestCase {
         assertTrue("Custom classLoader", source.getClass().getClassLoader() == custom  );
         
         
+    }
+
+    /**
+     * Verifies that the cache in {@link AbstractClassGenerator} SOURCE doesn't
+     * leak class definitions of classloaders that are no longer used.
+     */
+    public void testSourceCleanAfterClassLoaderDispose() throws Throwable {
+        ClassLoader custom = new ClassLoader(this.getClass().getClassLoader()) {
+
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                if (EA.class.getName().equals(name)) {
+                    InputStream classStream = this.getClass().getResourceAsStream("/net/sf/cglib/proxy/EA.class");
+                    byte[] classBytes;
+                    try {
+                        classBytes = toByteArray(classStream);
+                        return this.defineClass(null, classBytes, 0, classBytes.length);
+                    } catch (IOException e) {
+                        return super.loadClass(name);
+                    }
+                } else {
+                    return super.loadClass(name);
+                }
+            }
+        };
+
+        PhantomReference<ClassLoader> clRef = new PhantomReference<ClassLoader>(custom,
+                new ReferenceQueue<ClassLoader>());
+
+        buildAdvised(custom);
+        custom = null;
+
+        for (int i = 0; i < 10; ++i) {
+            System.gc();
+            Thread.sleep(100);
+            if (clRef.isEnqueued()) {
+                break;
+            }
+        }
+        assertTrue("CGLIB should allow classloaders to be evicted. PhantomReference<ClassLoader> was not cleared after 10 gc cycles," +
+                "thus it is likely some cache is preventing the class loader to be garbage collected", clRef.isEnqueued());
+
+    }
+
+    protected Object buildAdvised(ClassLoader custom)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        final Class<?> eaClassFromCustomClassloader = custom.loadClass(EA.class.getName());
+
+        CallbackFilter callbackFilter = new CallbackFilter() {
+            Object advised = eaClassFromCustomClassloader.newInstance();
+
+            public int accept(Method method) {
+                return 0;
+            }
+
+        };
+
+        Object source = enhance(eaClassFromCustomClassloader, null, callbackFilter, TEST_INTERCEPTOR, custom);
+        Object source2 = enhance(eaClassFromCustomClassloader, null, callbackFilter, TEST_INTERCEPTOR, custom);
+        assertEquals("enhance should return cached Enhancer when calling with same parameters",
+                source.getClass(), source2.getClass()
+        );
+        Object source3 = enhance(eaClassFromCustomClassloader, null, null, TEST_INTERCEPTOR, custom);
+        assertNotSame("enhance should return different instance when callbackFilter differs",
+                source.getClass(), source3.getClass()
+        );
+
+        return source;
+    }
+
+    private static byte[] toByteArray(InputStream input) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        int n = 0;
+
+        while (-1 != (n = input.read(buffer))) {
+            output.write(buffer, 0, n);
+        }
+
+        return output.toByteArray();
+
     }
 
     public void testRuntimException()throws Throwable{
@@ -483,6 +569,16 @@ public class TestEnhancer extends CodeGenTestCase {
         Enhancer e = new Enhancer();
         e.setSuperclass(cls);
         e.setInterfaces(interfaces);
+        e.setCallback(callback);
+        e.setClassLoader(loader);
+        return e.create();
+    }
+
+    public static Object enhance(Class cls, Class interfaces[], CallbackFilter callbackFilter, Callback callback, ClassLoader loader) {
+        Enhancer e = new Enhancer();
+        e.setSuperclass(cls);
+        e.setInterfaces(interfaces);
+        e.setCallbackFilter(callbackFilter);
         e.setCallback(callback);
         e.setClassLoader(loader);
         return e.create();

--- a/cglib/src/test/java/net/sf/cglib/proxy/TestMixin.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestMixin.java
@@ -35,6 +35,14 @@ public class TestMixin extends CodeGenTestCase {
 
     public void testDetermineInterfaces() throws Exception {
         Object obj = Mixin.create(new Object[]{ new D1(), new D2() });
+        Object obj2 = Mixin.create(new Object[]{ new D1(), new D2() });
+        assertEquals("Mixin.create should use exactly the same class when called with same parameters",
+                obj.getClass(), obj2.getClass()
+        );
+        Object obj3 = Mixin.create(new Object[]{ new D1(), new D4() });
+        assertNotSame("Mixin.create should use different classes for different parameters",
+                obj.getClass(), obj3.getClass()
+        );
         assertTrue(((DI1)obj).herby().equals("D1"));
         assertTrue(((DI2)obj).derby().equals("D2"));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,27 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.17</version>
+                    <configuration>
+                        <systemProperties>
+                            <property>
+                                <name>net.sf.cglib.test.stressHashCodes</name>
+                                <value>true</value>
+                            </property>
+                        </systemProperties>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>2.17</version>
+                    <configuration>
+                        <systemProperties>
+                            <property>
+                                <name>net.sf.cglib.test.stressHashCodes</name>
+                                <value>true</value>
+                            </property>
+                        </systemProperties>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Previously `KeyFactory` generated `java.lang.Class` fields even with `CLASS_BY_NAME` customization.
That might lead to unexpected class and classloader leak.
The fix ensures `KeyFactory` uses `java.lang.String` to store class names.
It should make no harm as CGLIB uses per-classloader cache, thus class name should be sufficiently unique.