### PR TITLE
Skip finalize while building proxy as there is no sense in doing that

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/ReflectUtils.java
+++ b/cglib/src/main/java/net/sf/cglib/core/ReflectUtils.java
@@ -35,6 +35,8 @@ public class ReflectUtils {
     private static final ClassLoader defaultLoader = ReflectUtils.class.getClassLoader();
     private static Method DEFINE_CLASS;
     private static final ProtectionDomain PROTECTION_DOMAIN;
+
+    private static final List<Method> OBJECT_METHODS = new ArrayList<Method>();
     
     static {
         PROTECTION_DOMAIN = getProtectionDomain(ReflectUtils.class);
@@ -58,6 +60,14 @@ public class ReflectUtils {
                 return null;
             }
         });
+        Method[] methods = Object.class.getDeclaredMethods();
+        for (Method method : methods) {
+            if ("finalize".equals(method.getName())
+                    || (method.getModifiers() & (Modifier.FINAL | Modifier.STATIC)) > 0) {
+                continue;
+            }
+            OBJECT_METHODS.add(method);
+        }
     }
         
     private static final String[] CGLIB_PACKAGES = {
@@ -352,7 +362,11 @@ public class ReflectUtils {
     public static List addAllMethods(final Class type, final List list) {
             
             
-        list.addAll(java.util.Arrays.asList(type.getDeclaredMethods()));
+        if (type == Object.class) {
+            list.addAll(OBJECT_METHODS);
+        } else
+            list.addAll(java.util.Arrays.asList(type.getDeclaredMethods()));
+
         Class superclass = type.getSuperclass();
         if (superclass != null) {
             addAllMethods(superclass, list);

--- a/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
@@ -131,6 +131,19 @@ public class TestEnhancer extends CodeGenTestCase {
         
     }
 
+    public void testFinalizeNotProxied() throws Throwable {
+        Source source = (Source) Enhancer.create(
+                Source.class,
+                null, TEST_INTERCEPTOR);
+
+        try {
+            Method finalize = source.getClass().getDeclaredMethod("finalize");
+            assertNull("CGLIB should enhanced object should not declare finalize() method so proxy objects are not eligible for finalization, thus faster", finalize);
+        } catch(NoSuchMethodException e) {
+            // expected
+        }
+    }
+
     public void testEnhanceObject() throws Throwable {
         EA obj = new EA();
         EA save = obj;

--- a/cglib/src/test/java/net/sf/cglib/reflect/TestFastClass.java
+++ b/cglib/src/test/java/net/sf/cglib/reflect/TestFastClass.java
@@ -70,22 +70,22 @@ public class TestFastClass extends net.sf.cglib.CodeGenTestCase {
     public void testComplex() throws Throwable {
         FastClass fc = FastClass.create(MemberSwitchBean.class);
         MemberSwitchBean bean = (MemberSwitchBean)fc.newInstance();
-        assertTrue(bean.init == 0);
-        assertTrue(fc.getName().equals("net.sf.cglib.reflect.MemberSwitchBean"));
-        assertTrue(fc.getJavaClass() == MemberSwitchBean.class);
-        assertTrue(fc.getMaxIndex() == 19);
+        assertEquals("bean.init", 0, bean.init);
+        assertEquals("fc.getName()", "net.sf.cglib.reflect.MemberSwitchBean", fc.getName());
+        assertEquals("fc.getJavaClass()", MemberSwitchBean.class, fc.getJavaClass());
+        assertEquals("fc.getMaxIndex()", 13, fc.getMaxIndex());
 
-        Constructor c1 = MemberSwitchBean.class.getConstructor(new Class[0]);
+        Constructor c1 = MemberSwitchBean.class.getConstructor();
         FastConstructor fc1 = fc.getConstructor(c1);
-        assertTrue(((MemberSwitchBean)fc1.newInstance()).init == 0);
-        assertTrue(fc1.toString().equals("public net.sf.cglib.reflect.MemberSwitchBean()"));
+        assertEquals("((MemberSwitchBean)fc1.newInstance()).init", 0, ((MemberSwitchBean)fc1.newInstance()).init);
+        assertEquals("fc1.toString()", "public net.sf.cglib.reflect.MemberSwitchBean()", fc1.toString());
 
-        Method m1 = MemberSwitchBean.class.getMethod("foo", new Class[]{ Integer.TYPE, String.class });
-        assertTrue(fc.getMethod(m1).invoke(bean, new Object[]{ new Integer(0), "" }).equals(new Integer(6)));
+        Method m1 = MemberSwitchBean.class.getMethod("foo", Integer.TYPE, String.class);
+        assertEquals("fc.getMethod(m1).invoke(bean, new Object[]{ new Integer(0), \"\" })", 6, fc.getMethod(m1).invoke(bean, new Object[]{0, ""}));
 
         // TODO: should null be allowed here?
         Method m2 = MemberSwitchBean.class.getDeclaredMethod("pkg", (Class[])null);
-        assertTrue(fc.getMethod(m2).invoke(bean, null).equals(new Integer(9)));
+        assertEquals("fc.getMethod(m2).invoke(bean, null)", 9, fc.getMethod(m2).invoke(bean, null));
     }
 
     public void testStatic() throws Throwable {


### PR DESCRIPTION
For best performance, proxy objects should not override #finalize as it does not make sense anyway

Before:
```
Benchmark                                        Mode  Cnt     Score     Error   Units
BeansBenchmark.newInstance                       avgt    5  2390,777 ± 163,965   ns/op
BeansBenchmark.newInstance:·gc.alloc.rate.norm   avgt    5  1240,001 ±   0,001    B/op
```

After:
```
Benchmark                                        Mode  Cnt     Score     Error   Units
BeansBenchmark.newInstance                       avgt    5  1786,696 ± 137,659   ns/op
BeansBenchmark.newInstance:·gc.alloc.rate.norm   avgt    5  1200,001 ±   0,001    B/op
```