### PR TITLE
Concurrent cache of generated classes

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/ClassesKey.java
+++ b/cglib/src/main/java/net/sf/cglib/core/ClassesKey.java
@@ -16,7 +16,7 @@
 package net.sf.cglib.core;
 
 public class ClassesKey {
-    private static final Key FACTORY = (Key)KeyFactory.create(Key.class, KeyFactory.OBJECT_BY_CLASS);
+    private static final Key FACTORY = (Key)KeyFactory.create(Key.class);
     
     interface Key {
         Object newInstance(Object[] array);
@@ -26,6 +26,21 @@ public class ClassesKey {
     }
 
     public static Object create(Object[] array) {
-        return FACTORY.newInstance(array);
+        return FACTORY.newInstance(classNames(array));
+    }
+
+    private static String[] classNames(Object[] objects) {
+        if (objects == null) {
+            return null;
+        }
+        String[] classNames = new String[objects.length];
+        for (int i = 0; i < objects.length; i++) {
+            Object object = objects[i];
+            if (object != null) {
+                Class<?> aClass = object.getClass();
+                classNames[i] = aClass == null ? null : aClass.getName();
+            }
+        }
+        return classNames;
     }
 }

--- a/cglib/src/main/java/net/sf/cglib/core/Constants.java
+++ b/cglib/src/main/java/net/sf/cglib/core/Constants.java
@@ -53,7 +53,8 @@ public interface Constants extends org.objectweb.asm.Opcodes {
     public static final Type TYPE_ERROR = TypeUtils.parseType("Error");
     public static final Type TYPE_SYSTEM = TypeUtils.parseType("System");
     public static final Type TYPE_SIGNATURE = TypeUtils.parseType("net.sf.cglib.core.Signature");
-    
+    public static final Type TYPE_TYPE = Type.getType(Type.class);
+
     public static final String CONSTRUCTOR_NAME = "<init>";
     public static final String STATIC_NAME = "<clinit>";
     public static final String SOURCE_FILE = "<generated>";

--- a/cglib/src/main/java/net/sf/cglib/core/Customizer.java
+++ b/cglib/src/main/java/net/sf/cglib/core/Customizer.java
@@ -17,6 +17,12 @@ package net.sf.cglib.core;
 
 import org.objectweb.asm.Type;
 
-public interface Customizer {
+/**
+ * Customizes key types for {@link KeyFactory} when building equals, hashCode, and toString.
+ * For customization of field types, use {@link FieldTypeCustomizer}
+ *
+ * @see KeyFactory#CLASS_BY_NAME
+ */
+public interface Customizer extends KeyFactoryCustomizer {
     void customize(CodeEmitter e, Type type);
 }

--- a/cglib/src/main/java/net/sf/cglib/core/DefaultNamingPolicy.java
+++ b/cglib/src/main/java/net/sf/cglib/core/DefaultNamingPolicy.java
@@ -29,6 +29,11 @@ import java.util.Set;
  */
 public class DefaultNamingPolicy implements NamingPolicy {
     public static final DefaultNamingPolicy INSTANCE = new DefaultNamingPolicy();
+
+    /**
+     * This allows to test collisions of {@code key.hashCode()}.
+     */
+    private final static boolean STRESS_HASH_CODE = Boolean.getBoolean("net.sf.cglib.test.stressHashCodes");
     
     public String getClassName(String prefix, String source, Object key, Predicate names) {
         if (prefix == null) {
@@ -40,7 +45,7 @@ public class DefaultNamingPolicy implements NamingPolicy {
             prefix + "$$" + 
             source.substring(source.lastIndexOf('.') + 1) +
             getTag() + "$$" +
-            Integer.toHexString(key.hashCode());
+            Integer.toHexString(STRESS_HASH_CODE ? 0 : key.hashCode());
         String attempt = base;
         int index = 2;
         while (names.evaluate(attempt))

--- a/cglib/src/main/java/net/sf/cglib/core/EmitUtils.java
+++ b/cglib/src/main/java/net/sf/cglib/core/EmitUtils.java
@@ -427,10 +427,19 @@ public class EmitUtils {
         Label end = e.make_label();
         e.dup();
         e.ifnull(skip);
-        for (Customizer customizer : registry.get(Customizer.class)) {
-            customizer.customize(e, type);
+        boolean customHashCode = false;
+        for (HashCodeCustomizer customizer : registry.get(HashCodeCustomizer.class)) {
+            if (customizer.customize(e, type)) {
+                customHashCode = true;
+                break;
+            }
         }
-        e.invoke_virtual(Constants.TYPE_OBJECT, HASH_CODE);
+        if (!customHashCode) {
+            for (Customizer customizer : registry.get(Customizer.class)) {
+                customizer.customize(e, type);
+            }
+            e.invoke_virtual(Constants.TYPE_OBJECT, HASH_CODE);
+        }
         e.goTo(end);
         e.mark(skip);
         e.pop();

--- a/cglib/src/main/java/net/sf/cglib/core/FieldTypeCustomizer.java
+++ b/cglib/src/main/java/net/sf/cglib/core/FieldTypeCustomizer.java
@@ -1,0 +1,23 @@
+package net.sf.cglib.core;
+
+import org.objectweb.asm.Type;
+
+/**
+ * Customizes key types for {@link KeyFactory} right in constructor.
+ */
+public interface FieldTypeCustomizer extends KeyFactoryCustomizer {
+    /**
+     * Customizes {@code this.FIELD_0 = ?} assignment in key constructor
+     * @param e code emitter
+     * @param index parameter index
+     * @param type parameter type
+     */
+    void customize(CodeEmitter e, int index, Type type);
+
+    /**
+     * Computes type of field for storing given parameter
+     * @param index parameter index
+     * @param type parameter type
+     */
+    Type getOutType(int index, Type type);
+}

--- a/cglib/src/main/java/net/sf/cglib/core/HashCodeCustomizer.java
+++ b/cglib/src/main/java/net/sf/cglib/core/HashCodeCustomizer.java
@@ -1,0 +1,12 @@
+package net.sf.cglib.core;
+
+import org.objectweb.asm.Type;
+
+public interface HashCodeCustomizer extends KeyFactoryCustomizer {
+    /**
+     * Customizes calculation of hashcode
+     * @param e code emitter
+     * @param type parameter type
+     */
+    boolean customize(CodeEmitter e, Type type);
+}

--- a/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
+++ b/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
@@ -16,11 +16,15 @@
 
 package net.sf.cglib.core;
 
-import java.lang.reflect.Method;
-import java.security.ProtectionDomain;
+import net.sf.cglib.core.internal.CustomizerRegistry;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
+
+import java.lang.reflect.Method;
+import java.security.ProtectionDomain;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Generates classes to handle multi-valued keys, for use in things such as Maps and Sets.
@@ -66,7 +70,9 @@ abstract public class KeyFactory {
       TypeUtils.parseSignature("StringBuffer append(String)");
     private static final Type KEY_FACTORY =
       TypeUtils.parseType("net.sf.cglib.core.KeyFactory");
-    
+    private static final Signature GET_SORT =
+      TypeUtils.parseSignature("int getSort()");
+
     //generated numbers: 
     private final static int PRIMES[] = {
                11,         73,        179,       331,
@@ -92,6 +98,26 @@ abstract public class KeyFactory {
         }
     };
 
+    public static final FieldTypeCustomizer STORE_CLASS_AS_STRING = new FieldTypeCustomizer() {
+        public void customize(CodeEmitter e, int index, Type type) {
+            if (type.equals(Constants.TYPE_CLASS)) {
+                e.invoke_virtual(Constants.TYPE_CLASS, GET_NAME);
+            }
+        }
+
+        public Type getOutType(int index, Type type) {
+            if (type.equals(Constants.TYPE_CLASS)) {
+                return Constants.TYPE_STRING;
+            }
+            return type;
+        }
+    };
+
+    /**
+     * @deprecated this customizer might result in unexpected class leak since key object still holds a strong reference to the Object and class.
+     *             It is recommended to have pre-processing method that would strip Objects and represent Classes as Strings
+     */
+    @Deprecated
     public static final Customizer OBJECT_BY_CLASS = new Customizer() {
         public void customize(CodeEmitter e, Type type) {
             e.invoke_virtual(Constants.TYPE_OBJECT, GET_CLASS);
@@ -109,18 +135,37 @@ abstract public class KeyFactory {
         return create(keyInterface.getClassLoader(), keyInterface,  customizer);
     }
 
+    public static KeyFactory create(Class keyInterface, KeyFactoryCustomizer first, List<KeyFactoryCustomizer> next) {
+        return create(keyInterface.getClassLoader(), keyInterface, first, next);
+    }
+
     public static KeyFactory create(ClassLoader loader, Class keyInterface, Customizer customizer) {
+        return create(loader, keyInterface, customizer, Collections.<KeyFactoryCustomizer>emptyList());
+    }
+
+    public static KeyFactory create(ClassLoader loader, Class keyInterface, KeyFactoryCustomizer customizer,
+                                    List<KeyFactoryCustomizer> next) {
         Generator gen = new Generator();
         gen.setInterface(keyInterface);
-        gen.setCustomizer(customizer);
+
+        if (customizer != null) {
+            gen.addCustomizer(customizer);
+        }
+        if (next != null && !next.isEmpty()) {
+            for (KeyFactoryCustomizer keyFactoryCustomizer : next) {
+                gen.addCustomizer(keyFactoryCustomizer);
+            }
+        }
         gen.setClassLoader(loader);
         return gen.create();
     }
 
     public static class Generator extends AbstractClassGenerator {
         private static final Source SOURCE = new Source(KeyFactory.class.getName());
+        private static final Class[] KNOWN_CUSTOMIZER_TYPES = new Class[]{Customizer.class, FieldTypeCustomizer.class};
+
         private Class keyInterface;
-        private Customizer customizer;
+        private final CustomizerRegistry customizers = new CustomizerRegistry(KNOWN_CUSTOMIZER_TYPES);
         private int constant;
         private int multiplier;
 
@@ -136,8 +181,12 @@ abstract public class KeyFactory {
         	return ReflectUtils.getProtectionDomain(keyInterface);
         }
 
-        public void setCustomizer(Customizer customizer) {
-            this.customizer = customizer;
+        public void addCustomizer(KeyFactoryCustomizer customizer) {
+            customizers.add(customizer);
+        }
+
+        public <T> List<T> getCustomizers(Class<T> klass) {
+            return customizers.get(klass);
         }
 
         public void setInterface(Class keyInterface) {
@@ -190,14 +239,23 @@ abstract public class KeyFactory {
             e.load_this();
             e.super_invoke_constructor();
             e.load_this();
+            List<FieldTypeCustomizer> fieldTypeCustomizers = getCustomizers(FieldTypeCustomizer.class);
             for (int i = 0; i < parameterTypes.length; i++) {
-                seed += parameterTypes[i].hashCode();
+                Type parameterType = parameterTypes[i];
+                Type fieldType = parameterType;
+                for (FieldTypeCustomizer customizer : fieldTypeCustomizers) {
+                    fieldType = customizer.getOutType(i, fieldType);
+                }
+                seed += fieldType.hashCode();
                 ce.declare_field(Constants.ACC_PRIVATE | Constants.ACC_FINAL,
                                  getFieldName(i),
-                                 parameterTypes[i],
+                                 fieldType,
                                  null);
                 e.dup();
                 e.load_arg(i);
+                for (FieldTypeCustomizer customizer : fieldTypeCustomizers) {
+                    customizer.customize(e, i, parameterType);
+                }
                 e.putfield(getFieldName(i));
             }
             e.return_value();
@@ -211,7 +269,7 @@ abstract public class KeyFactory {
             for (int i = 0; i < parameterTypes.length; i++) {
                 e.load_this();
                 e.getfield(getFieldName(i));
-                EmitUtils.hash_code(e, parameterTypes[i], hm, customizer);
+                EmitUtils.hash_code(e, parameterTypes[i], hm, customizers);
             }
             e.return_value();
             e.end_method();
@@ -228,7 +286,7 @@ abstract public class KeyFactory {
                 e.load_arg(0);
                 e.checkcast_this();
                 e.getfield(getFieldName(i));
-                EmitUtils.not_equals(e, parameterTypes[i], fail, customizer);
+                EmitUtils.not_equals(e, parameterTypes[i], fail, customizers);
             }
             e.push(1);
             e.return_value();
@@ -249,7 +307,7 @@ abstract public class KeyFactory {
                 }
                 e.load_this();
                 e.getfield(getFieldName(i));
-                EmitUtils.append_string(e, parameterTypes[i], EmitUtils.DEFAULT_DELIMITERS, customizer);
+                EmitUtils.append_string(e, parameterTypes[i], EmitUtils.DEFAULT_DELIMITERS, customizers);
             }
             e.invoke_virtual(Constants.TYPE_STRING_BUFFER, TO_STRING);
             e.return_value();

--- a/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
+++ b/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
@@ -114,6 +114,20 @@ abstract public class KeyFactory {
     };
 
     /**
+     * {@link Type#hashCode()} is very expensive as it traverses full descriptor to calculate hash code.
+     * This customizer uses {@link Type#getSort()} as a hash code.
+     */
+    public static final HashCodeCustomizer HASH_ASM_TYPE = new HashCodeCustomizer() {
+        public boolean customize(CodeEmitter e, Type type) {
+            if (Constants.TYPE_TYPE.equals(type)) {
+                e.invoke_virtual(type, GET_SORT);
+                return true;
+            }
+            return false;
+        }
+    };
+
+    /**
      * @deprecated this customizer might result in unexpected class leak since key object still holds a strong reference to the Object and class.
      *             It is recommended to have pre-processing method that would strip Objects and represent Classes as Strings
      */

--- a/cglib/src/main/java/net/sf/cglib/core/KeyFactoryCustomizer.java
+++ b/cglib/src/main/java/net/sf/cglib/core/KeyFactoryCustomizer.java
@@ -1,0 +1,7 @@
+package net.sf.cglib.core;
+
+/**
+ * Marker interface for customizers of {@link KeyFactory}
+ */
+public interface KeyFactoryCustomizer {
+}

--- a/cglib/src/main/java/net/sf/cglib/core/ReflectUtils.java
+++ b/cglib/src/main/java/net/sf/cglib/core/ReflectUtils.java
@@ -35,6 +35,8 @@ public class ReflectUtils {
     private static final ClassLoader defaultLoader = ReflectUtils.class.getClassLoader();
     private static Method DEFINE_CLASS;
     private static final ProtectionDomain PROTECTION_DOMAIN;
+
+    private static final List<Method> OBJECT_METHODS = new ArrayList<Method>();
     
     static {
         PROTECTION_DOMAIN = getProtectionDomain(ReflectUtils.class);
@@ -58,6 +60,14 @@ public class ReflectUtils {
                 return null;
             }
         });
+        Method[] methods = Object.class.getDeclaredMethods();
+        for (Method method : methods) {
+            if ("finalize".equals(method.getName())
+                    || (method.getModifiers() & (Modifier.FINAL | Modifier.STATIC)) > 0) {
+                continue;
+            }
+            OBJECT_METHODS.add(method);
+        }
     }
         
     private static final String[] CGLIB_PACKAGES = {
@@ -352,7 +362,11 @@ public class ReflectUtils {
     public static List addAllMethods(final Class type, final List list) {
             
             
-        list.addAll(java.util.Arrays.asList(type.getDeclaredMethods()));
+        if (type == Object.class) {
+            list.addAll(OBJECT_METHODS);
+        } else
+            list.addAll(java.util.Arrays.asList(type.getDeclaredMethods()));
+
         Class superclass = type.getSuperclass();
         if (superclass != null) {
             addAllMethods(superclass, list);

--- a/cglib/src/main/java/net/sf/cglib/core/WeakIdentityKey.java
+++ b/cglib/src/main/java/net/sf/cglib/core/WeakIdentityKey.java
@@ -1,0 +1,40 @@
+package net.sf.cglib.core;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Allows to check for reference identity, yet the class does not keep strong reference to the target.
+ * {@link #equals(Object)} returns true if and only if the reference is not yet expired and other
+ * object is referencing exactly the same object.
+ *
+ * @param <T> type of the reference
+ */
+public class WeakIdentityKey<T> extends WeakReference<T> {
+    private final int hash;
+
+    public WeakIdentityKey(T referent) {
+        super(referent);
+        this.hash = System.identityHashCode(referent);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof WeakIdentityKey)) {
+            return false;
+        }
+        Object ours = get();
+        Object theirs = ((WeakIdentityKey) obj).get();
+        return ours == theirs && ours != null;
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        T t = get();
+        return t == null ? "Clean WeakIdentityKey, hash: " + hash : t.toString();
+    }
+}

--- a/cglib/src/main/java/net/sf/cglib/core/internal/CustomizerRegistry.java
+++ b/cglib/src/main/java/net/sf/cglib/core/internal/CustomizerRegistry.java
@@ -1,0 +1,35 @@
+package net.sf.cglib.core.internal;
+
+import net.sf.cglib.core.KeyFactoryCustomizer;
+
+import java.util.*;
+
+public class CustomizerRegistry {
+    private final Class[] customizerTypes;
+    private Map<Class, List<KeyFactoryCustomizer>> customizers = new HashMap<Class, List<KeyFactoryCustomizer>>();
+
+    public CustomizerRegistry(Class[] customizerTypes) {
+        this.customizerTypes = customizerTypes;
+    }
+
+    public void add(KeyFactoryCustomizer customizer) {
+        Class<? extends KeyFactoryCustomizer> klass = customizer.getClass();
+        for (Class type : customizerTypes) {
+            if (type.isAssignableFrom(klass)) {
+                List<KeyFactoryCustomizer> list = customizers.get(type);
+                if (list == null) {
+                    customizers.put(type, list = new ArrayList<KeyFactoryCustomizer>());
+                }
+                list.add(customizer);
+            }
+        }
+    }
+
+    public <T> List<T> get(Class<T> klass) {
+        List<KeyFactoryCustomizer> list = customizers.get(klass);
+        if (list == null) {
+            return Collections.emptyList();
+        }
+        return (List<T>) list;
+    }
+}

--- a/cglib/src/main/java/net/sf/cglib/core/internal/Function.java
+++ b/cglib/src/main/java/net/sf/cglib/core/internal/Function.java
@@ -1,0 +1,5 @@
+package net.sf.cglib.core.internal;
+
+public interface Function<K, V> {
+    V apply(K key);
+}

--- a/cglib/src/main/java/net/sf/cglib/core/internal/LoadingCache.java
+++ b/cglib/src/main/java/net/sf/cglib/core/internal/LoadingCache.java
@@ -1,0 +1,86 @@
+package net.sf.cglib.core.internal;
+
+import java.util.concurrent.*;
+
+public class LoadingCache<K, KK, V> {
+    protected final ConcurrentMap<KK, Object> map;
+    protected final Function<K, V> loader;
+    protected final Function<K, KK> keyMapper;
+
+    public static final Function IDENTITY = new Function() {
+        public Object apply(Object key) {
+            return key;
+        }
+    };
+
+    public LoadingCache(Function<K, KK> keyMapper, Function<K, V> loader) {
+        this.keyMapper = keyMapper;
+        this.loader = loader;
+        this.map = new ConcurrentHashMap<KK, Object>();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <K> Function<K, K> identity() {
+        return IDENTITY;
+    }
+
+    public V get(K key) {
+        final KK cacheKey = keyMapper.apply(key);
+        Object v = map.get(cacheKey);
+        if (v != null && !(v instanceof FutureTask)) {
+            return (V) v;
+        }
+
+        return createEntry(key, cacheKey, v);
+    }
+
+    /**
+     * Loads entry to the cache.
+     * If entry is missing, put {@link FutureTask} first so other competing thread might wait for the result.
+     * @param key original key that would be used to load the instance
+     * @param cacheKey key that would be used to store the entry in internal map
+     * @param v null or {@link FutureTask<V>}
+     * @return newly created instance
+     */
+    protected V createEntry(final K key, KK cacheKey, Object v) {
+        FutureTask<V> task;
+        boolean creator = false;
+        if (v != null) {
+            // Another thread is already loading an instance
+            task = (FutureTask<V>) v;
+        } else {
+            task = new FutureTask<V>(new Callable<V>() {
+                public V call() throws Exception {
+                    return loader.apply(key);
+                }
+            });
+            Object prevTask = map.putIfAbsent(cacheKey, task);
+            if (prevTask == null) {
+                // creator does the load
+                creator = true;
+                task.run();
+            } else if (prevTask instanceof FutureTask) {
+                task = (FutureTask<V>) prevTask;
+            } else {
+                return (V) prevTask;
+            }
+        }
+
+        V result;
+        try {
+            result = task.get();
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("Interrupted while loading cache item", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw ((RuntimeException) cause);
+            }
+            throw new IllegalStateException("Unable to load cache item", cause);
+        }
+        if (creator) {
+            map.put(cacheKey, result);
+        }
+        return result;
+    }
+}

--- a/cglib/src/main/java/net/sf/cglib/proxy/CallbackInfo.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/CallbackInfo.java
@@ -20,17 +20,25 @@ import org.objectweb.asm.Type;
 class CallbackInfo
 {
     public static Type[] determineTypes(Class[] callbackTypes) {
+        return determineTypes(callbackTypes, true);
+    }
+
+    public static Type[] determineTypes(Class[] callbackTypes, boolean checkAll) {
         Type[] types = new Type[callbackTypes.length];
         for (int i = 0; i < types.length; i++) {
-            types[i] = determineType(callbackTypes[i]);
+            types[i] = determineType(callbackTypes[i], checkAll);
         }
         return types;
     }
 
     public static Type[] determineTypes(Callback[] callbacks) {
+        return determineTypes(callbacks, true);
+    }
+
+    public static Type[] determineTypes(Callback[] callbacks, boolean checkAll) {
         Type[] types = new Type[callbacks.length];
         for (int i = 0; i < types.length; i++) {
-            types[i] = determineType(callbacks[i]);
+            types[i] = determineType(callbacks[i], checkAll);
         }
         return types;
     }
@@ -65,15 +73,16 @@ class CallbackInfo
         type = Type.getType(cls);
     }
 
-    private static Type determineType(Callback callback) {
+    private static Type determineType(Callback callback, boolean checkAll) {
         if (callback == null) {
             throw new IllegalStateException("Callback is null");
         }
-        return determineType(callback.getClass());
+        return determineType(callback.getClass(), checkAll);
     }
 
-    private static Type determineType(Class callbackType) {
+    private static Type determineType(Class callbackType, boolean checkAll) {
         Class cur = null;
+        Type type = null;
         for (int i = 0; i < CALLBACKS.length; i++) {
             CallbackInfo info = CALLBACKS[i];
             if (info.cls.isAssignableFrom(callbackType)) {
@@ -81,12 +90,16 @@ class CallbackInfo
                     throw new IllegalStateException("Callback implements both " + cur + " and " + info.cls);
                 }
                 cur = info.cls;
+                type = info.type;
+                if (!checkAll) {
+                    break;
+                }
             }
         }
         if (cur == null) {
             throw new IllegalStateException("Unknown callback type " + callbackType);
         }
-        return Type.getType(cur);
+        return type;
     }
 
     private static CallbackGenerator getGenerator(Type callbackType) {

--- a/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
@@ -66,7 +66,7 @@ public class Enhancer extends AbstractClassGenerator
 
     private static final Source SOURCE = new Source(Enhancer.class.getName());
     private static final EnhancerKey KEY_FACTORY =
-      (EnhancerKey)KeyFactory.create(EnhancerKey.class);
+      (EnhancerKey)KeyFactory.create(EnhancerKey.class, KeyFactory.HASH_ASM_TYPE, null);
 
     private static final String BOUND_FIELD = "CGLIB$BOUND";
     private static final String THREAD_CALLBACKS_FIELD = "CGLIB$THREAD_CALLBACKS";

--- a/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
@@ -15,13 +15,11 @@
  */
 package net.sf.cglib.proxy;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.ProtectionDomain;
 import java.util.*;
 import net.sf.cglib.core.*;
-import org.objectweb.asm.Attribute;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.Label;
@@ -124,7 +122,7 @@ public class Enhancer extends AbstractClassGenerator
     public interface EnhancerKey {
         public Object newInstance(String type,
                                   String[] interfaces,
-                                  CallbackFilter filter,
+                                  WeakIdentityKey<CallbackFilter> filter,
                                   Type[] callbackTypes,
                                   boolean useFactory,
                                   boolean interceptDuringConstruction,
@@ -377,7 +375,7 @@ public class Enhancer extends AbstractClassGenerator
         }
         return super.create(KEY_FACTORY.newInstance((superclass != null) ? superclass.getName() : null,
                                                     ReflectUtils.getNames(interfaces),
-                                                    filter,
+                                                    filter == ALL_ZERO ? null : new WeakIdentityKey<CallbackFilter>(filter),
                                                     callbackTypes,
                                                     useFactory,
                                                     interceptDuringConstruction,

--- a/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
@@ -15,10 +15,14 @@
  */
 package net.sf.cglib.proxy;
 
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.ProtectionDomain;
 import java.util.*;
+
 import net.sf.cglib.core.*;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Type;
@@ -67,14 +71,19 @@ public class Enhancer extends AbstractClassGenerator
     private static final Source SOURCE = new Source(Enhancer.class.getName());
     private static final EnhancerKey KEY_FACTORY =
       (EnhancerKey)KeyFactory.create(EnhancerKey.class, KeyFactory.HASH_ASM_TYPE, null);
+    private static final EnhancerFactoryKey FACTORY_KEY_FACTORY =
+      (EnhancerFactoryKey)KeyFactory.create(EnhancerFactoryKey.class);
 
     private static final String BOUND_FIELD = "CGLIB$BOUND";
+    private static final String FACTORY_DATA_FIELD = "CGLIB$FACTORY_DATA";
     private static final String THREAD_CALLBACKS_FIELD = "CGLIB$THREAD_CALLBACKS";
     private static final String STATIC_CALLBACKS_FIELD = "CGLIB$STATIC_CALLBACKS";
     private static final String SET_THREAD_CALLBACKS_NAME = "CGLIB$SET_THREAD_CALLBACKS";
     private static final String SET_STATIC_CALLBACKS_NAME = "CGLIB$SET_STATIC_CALLBACKS";
     private static final String CONSTRUCTED_FIELD = "CGLIB$CONSTRUCTED";
 
+    private static final Type OBJECT_TYPE =
+      TypeUtils.parseType("Object");
     private static final Type FACTORY =
       TypeUtils.parseType("net.sf.cglib.proxy.Factory");
     private static final Type ILLEGAL_STATE_EXCEPTION =
@@ -118,6 +127,9 @@ public class Enhancer extends AbstractClassGenerator
     private static final Signature BIND_CALLBACKS =
       TypeUtils.parseSignature("void CGLIB$BIND_CALLBACKS(Object)");
 
+    private EnhancerFactoryData currentData;
+    private Object currentKey;
+
     /** Internal interface, only public due to ClassLoader issues. */
     public interface EnhancerKey {
         public Object newInstance(String type,
@@ -129,11 +141,18 @@ public class Enhancer extends AbstractClassGenerator
                                   Long serialVersionUID);
     }
 
+    /** Internal interface, only public due to ClassLoader issues. */
+    public interface EnhancerFactoryKey {
+        Object newInstance(EnhancerKey key);
+    }
+
     private Class[] interfaces;
     private CallbackFilter filter;
     private Callback[] callbacks;
     private Type[] callbackTypes;
+    private boolean validateCallbackTypes;
     private boolean classOnly;
+    private boolean factoryOnly;
     private Class superclass;
     private Class[] argumentTypes;
     private Object[] arguments;
@@ -280,6 +299,7 @@ public class Enhancer extends AbstractClassGenerator
      */
     public Object create() {
         classOnly = false;
+        factoryOnly = false;
         argumentTypes = null;
         return createHelper();
     }
@@ -295,6 +315,7 @@ public class Enhancer extends AbstractClassGenerator
      */
     public Object create(Class[] argumentTypes, Object[] arguments) {
         classOnly = false;
+        factoryOnly = false;
         if (argumentTypes == null || arguments == null || argumentTypes.length != arguments.length) {
             throw new IllegalArgumentException("Arguments must be non-null and of equal length");
         }
@@ -313,7 +334,21 @@ public class Enhancer extends AbstractClassGenerator
      */
     public Class createClass() {
         classOnly = true;
+        factoryOnly = false;
         return (Class)createHelper();
+    }
+
+    /**
+     * Generate a {@link Factory} implementation if necessary and return it.
+     * This ignores any callbacks that have been set.
+     * @see Factory#newInstance(Callback)
+     * @see Factory#newInstance(Callback[])
+     * @see Factory#newInstance(Class[], Object[], Callback[])
+     */
+    public Factory createFactory() {
+        classOnly = false;
+        factoryOnly = true;
+        return (Factory)createHelper();
     }
 
     /**
@@ -322,6 +357,19 @@ public class Enhancer extends AbstractClassGenerator
      */
     public void setSerialVersionUID(Long sUID) {
         serialVersionUID = sUID;
+    }
+
+    private void preValidate() {
+        if (callbackTypes == null) {
+            callbackTypes = CallbackInfo.determineTypes(callbacks, false);
+            validateCallbackTypes = true;
+        }
+        if (filter == null) {
+            if (callbackTypes.length > 1) {
+                throw new IllegalStateException("Multiple callback types possible but no filter specified");
+            }
+            filter = ALL_ZERO;
+        }
     }
 
     private void validate() {
@@ -334,6 +382,9 @@ public class Enhancer extends AbstractClassGenerator
         }
         if (classOnly && (callbackTypes == null)) {
             throw new IllegalStateException("Callback types are required");
+        }
+        if (validateCallbackTypes) {
+            callbackTypes = null;
         }
         if (callbacks != null && callbackTypes != null) {
             if (callbacks.length != callbackTypes.length) {
@@ -348,12 +399,6 @@ public class Enhancer extends AbstractClassGenerator
         } else if (callbacks != null) {
             callbackTypes = CallbackInfo.determineTypes(callbacks);
         }
-        if (filter == null) {
-            if (callbackTypes.length > 1) {
-                throw new IllegalStateException("Multiple callback types possible but no filter specified");
-            }
-            filter = ALL_ZERO;
-        }
         if (interfaces != null) {
             for (int i = 0; i < interfaces.length; i++) {
                 if (interfaces[i] == null) {
@@ -366,20 +411,38 @@ public class Enhancer extends AbstractClassGenerator
         }
     }
 
+    static class EnhancerFactoryData {
+        public final Class generatedClass;
+        public volatile Factory factory;
+
+        public EnhancerFactoryData(Class generatedClass) {
+            this.generatedClass = generatedClass;
+        }
+    }
+
     private Object createHelper() {
+        preValidate();
+        Object key = KEY_FACTORY.newInstance((superclass != null) ? superclass.getName() : null,
+                ReflectUtils.getNames(interfaces),
+                filter == ALL_ZERO ? null : new WeakIdentityKey<CallbackFilter>(filter),
+                callbackTypes,
+                useFactory,
+                interceptDuringConstruction,
+                serialVersionUID);
+        this.currentKey = key;
+        Object result = super.create(key);
+        return result;
+    }
+
+    @Override
+    protected Class generate(ClassLoaderData data) {
         validate();
         if (superclass != null) {
             setNamePrefix(superclass.getName());
         } else if (interfaces != null) {
             setNamePrefix(interfaces[ReflectUtils.findPackageProtected(interfaces)].getName());
         }
-        return super.create(KEY_FACTORY.newInstance((superclass != null) ? superclass.getName() : null,
-                                                    ReflectUtils.getNames(interfaces),
-                                                    filter == ALL_ZERO ? null : new WeakIdentityKey<CallbackFilter>(filter),
-                                                    callbackTypes,
-                                                    useFactory,
-                                                    interceptDuringConstruction,
-                                                    serialVersionUID));
+        return super.generate(data);
     }
 
     protected ClassLoader getDefaultClassLoader() {
@@ -480,6 +543,7 @@ public class Enhancer extends AbstractClassGenerator
         });
 
         ClassEmitter e = new ClassEmitter(v);
+        if (currentData == null) {
         e.begin_class(Constants.V1_2,
                       Constants.ACC_PUBLIC,
                       getClassName(),
@@ -488,9 +552,18 @@ public class Enhancer extends AbstractClassGenerator
                        TypeUtils.add(TypeUtils.getTypes(interfaces), FACTORY) :
                        TypeUtils.getTypes(interfaces)),
                       Constants.SOURCE_FILE);
+        } else {
+            e.begin_class(Constants.V1_2,
+                    Constants.ACC_PUBLIC,
+                    getClassName(),
+                    null,
+                    new Type[]{FACTORY},
+                    Constants.SOURCE_FILE);
+        }
         List constructorInfo = CollectionUtils.transform(constructors, MethodInfoTransformer.getInstance());
 
         e.declare_field(Constants.ACC_PRIVATE, BOUND_FIELD, Type.BOOLEAN_TYPE, null);
+        e.declare_field(Constants.ACC_PUBLIC | Constants.ACC_STATIC, FACTORY_DATA_FIELD, OBJECT_TYPE, null);
         if (!interceptDuringConstruction) {
             e.declare_field(Constants.ACC_PRIVATE, CONSTRUCTED_FIELD, Type.BOOLEAN_TYPE, null);
         }
@@ -504,13 +577,17 @@ public class Enhancer extends AbstractClassGenerator
             e.declare_field(Constants.ACC_PRIVATE, getCallbackField(i), callbackTypes[i], null);
         }
 
-        emitMethods(e, methods, actualMethods);
-        emitConstructors(e, constructorInfo);
+        if (currentData == null) {
+            emitMethods(e, methods, actualMethods);
+            emitConstructors(e, constructorInfo);
+        } else {
+            emitDefaultConstructor(e);
+        }
         emitSetThreadCallbacks(e);
         emitSetStaticCallbacks(e);
         emitBindCallbacks(e);
 
-        if (useFactory) {
+        if (useFactory || currentData != null) {
             int[] keys = getCallbackKeys();
             emitNewInstanceCallbacks(e);
             emitNewInstanceCallback(e);
@@ -541,6 +618,7 @@ public class Enhancer extends AbstractClassGenerator
     }
 
     protected Object firstInstance(Class type) throws Exception {
+        // Should not reach here
         if (classOnly) {
             return type;
         } else {
@@ -549,18 +627,54 @@ public class Enhancer extends AbstractClassGenerator
     }
 
     protected Object nextInstance(Object instance) {
-        Class protoclass = (instance instanceof Class) ? (Class)instance : instance.getClass();
-        if (classOnly) {
-            return protoclass;
-        } else if (instance instanceof Factory) {
-            if (argumentTypes != null) {
-                return ((Factory)instance).newInstance(argumentTypes, arguments, callbacks);
-            } else {
-                return ((Factory)instance).newInstance(callbacks);
-            }
-        } else {
-            return createUsingReflection(protoclass);
+        if (currentKey instanceof EnhancerFactoryKey) {
+            return instance;
         }
+
+        EnhancerFactoryData data = (EnhancerFactoryData) instance;
+        if (classOnly) {
+            return data.generatedClass;
+        }
+        Factory factory = data.factory;
+        if (factory == null) {
+            this.currentData = data;
+            Object factoryKey = FACTORY_KEY_FACTORY.newInstance((EnhancerKey) currentKey);
+            this.currentKey = factoryKey;
+            factory = (Factory) super.create(factoryKey);
+            this.currentData = null;
+            data.factory = factory;
+        }
+        if (factoryOnly) {
+            return factory;
+        }
+        return createUsingFactory(factory);
+    }
+
+    @Override
+    protected Object wrapCachedClass(Class klass) {
+        if (currentKey instanceof EnhancerFactoryKey) {
+            return new WeakReference(ReflectUtils.newInstance(klass));
+        }
+        EnhancerFactoryData factoryData = new EnhancerFactoryData(klass);
+        Field factoryDataField = null;
+        try {
+            factoryDataField = klass.getField(FACTORY_DATA_FIELD);
+            factoryDataField.set(null, factoryData);
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        return new WeakReference<EnhancerFactoryData>(factoryData);
+    }
+
+    @Override
+    protected Object unwrapCachedValue(Object cached) {
+        if (currentKey instanceof EnhancerKey) {
+            EnhancerFactoryData data = ((WeakReference<EnhancerFactoryData>) cached).get();
+            return data;
+        }
+        return super.unwrapCachedValue(cached);
     }
 
     /**
@@ -658,6 +772,14 @@ public class Enhancer extends AbstractClassGenerator
         }
     }
 
+    private Object createUsingFactory(Factory factory) {
+        if (argumentTypes != null) {
+            return factory.newInstance(argumentTypes, arguments, callbacks);
+        } else {
+            return factory.newInstance(callbacks);
+        }
+    }
+
     /**
      * Helper method to create an intercepted object.
      * For finer control over the generated instance, use a new instance of <code>Enhancer</code>
@@ -706,10 +828,30 @@ public class Enhancer extends AbstractClassGenerator
         return e.create();
     }
 
+    private void emitDefaultConstructor(ClassEmitter ce) {
+        Constructor<Object> declaredConstructor;
+        try {
+            declaredConstructor = Object.class.getDeclaredConstructor();
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Object should have default constructor ", e);
+        }
+        MethodInfo constructor = (MethodInfo) MethodInfoTransformer.getInstance().transform(declaredConstructor);
+        CodeEmitter e = EmitUtils.begin_method(ce, constructor, Constants.ACC_PUBLIC);
+        e.load_this();
+        e.dup();
+        Signature sig = constructor.getSignature();
+        e.super_invoke_constructor(sig);
+        e.return_value();
+        e.end_method();
+    }
+
     private void emitConstructors(ClassEmitter ce, List constructors) {
         boolean seenNull = false;
         for (Iterator it = constructors.iterator(); it.hasNext();) {
             MethodInfo constructor = (MethodInfo)it.next();
+            if (currentData != null && !"()V".equals(constructor.getSignature().getDescriptor())) {
+                continue;
+            }
             CodeEmitter e = EmitUtils.begin_method(ce, constructor, Constants.ACC_PUBLIC);
             e.load_this();
             e.dup();
@@ -717,11 +859,13 @@ public class Enhancer extends AbstractClassGenerator
             Signature sig = constructor.getSignature();
             seenNull = seenNull || sig.getDescriptor().equals("()V");
             e.super_invoke_constructor(sig);
-            e.invoke_static_this(BIND_CALLBACKS);
-            if (!interceptDuringConstruction) {
-                e.load_this();
-                e.push(1);
-                e.putfield(CONSTRUCTED_FIELD);
+            if (currentData == null) {
+                e.invoke_static_this(BIND_CALLBACKS);
+                if (!interceptDuringConstruction) {
+                    e.load_this();
+                    e.push(1);
+                    e.putfield(CONSTRUCTED_FIELD);
+                }
             }
             e.return_value();
             e.end_method();
@@ -811,17 +955,27 @@ public class Enhancer extends AbstractClassGenerator
 
     private void emitNewInstanceCallbacks(ClassEmitter ce) {
         CodeEmitter e = ce.begin_method(Constants.ACC_PUBLIC, NEW_INSTANCE, null);
+        Type thisType = getThisType(e);
         e.load_arg(0);
-        e.invoke_static_this(SET_THREAD_CALLBACKS);
+        e.invoke_static(thisType, SET_THREAD_CALLBACKS);
         emitCommonNewInstance(e);
     }
 
+    private Type getThisType(CodeEmitter e) {
+        if (currentData == null) {
+            return e.getClassEmitter().getClassType();
+        } else {
+            return Type.getType(currentData.generatedClass);
+        }
+    }
+
     private void emitCommonNewInstance(CodeEmitter e) {
-        e.new_instance_this();
+        Type thisType = getThisType(e);
+        e.new_instance(thisType);
         e.dup();
-        e.invoke_constructor_this();
+        e.invoke_constructor(thisType);
         e.aconst_null();
-        e.invoke_static_this(SET_THREAD_CALLBACKS);
+        e.invoke_static(thisType, SET_THREAD_CALLBACKS);
         e.return_value();
         e.end_method();
     }
@@ -840,7 +994,7 @@ public class Enhancer extends AbstractClassGenerator
             e.push(0);
             e.load_arg(0);
             e.aastore();
-            e.invoke_static_this(SET_THREAD_CALLBACKS);
+            e.invoke_static(getThisType(e), SET_THREAD_CALLBACKS);
             break;
         default:
             e.throw_exception(ILLEGAL_STATE_EXCEPTION, "More than one callback object required");
@@ -850,9 +1004,10 @@ public class Enhancer extends AbstractClassGenerator
 
     private void emitNewInstanceMultiarg(ClassEmitter ce, List constructors) {
         final CodeEmitter e = ce.begin_method(Constants.ACC_PUBLIC, MULTIARG_NEW_INSTANCE, null);
+        final Type thisType = getThisType(e);
         e.load_arg(2);
-        e.invoke_static_this(SET_THREAD_CALLBACKS);
-        e.new_instance_this();
+        e.invoke_static(thisType, SET_THREAD_CALLBACKS);
+        e.new_instance(thisType);
         e.dup();
         e.load_arg(0);
         EmitUtils.constructor_switch(e, constructors, new ObjectSwitchCallback() {
@@ -865,7 +1020,7 @@ public class Enhancer extends AbstractClassGenerator
                     e.aaload();
                     e.unbox(types[i]);
                 }
-                e.invoke_constructor_this(constructor.getSignature());
+                e.invoke_constructor(thisType, constructor.getSignature());
                 e.goTo(end);
             }
             public void processDefault() {
@@ -873,7 +1028,7 @@ public class Enhancer extends AbstractClassGenerator
             }
         });
         e.aconst_null();
-        e.invoke_static_this(SET_THREAD_CALLBACKS);
+        e.invoke_static(thisType, SET_THREAD_CALLBACKS);
         e.return_value();
         e.end_method();
     }

--- a/cglib/src/test/java/net/sf/cglib/beans/TestBeanMap.java
+++ b/cglib/src/test/java/net/sf/cglib/beans/TestBeanMap.java
@@ -23,6 +23,10 @@ import java.util.*;
 import junit.framework.*;
 
 public class TestBeanMap extends net.sf.cglib.CodeGenTestCase {
+    public static class TestBean2 {
+        private String foo;
+    }
+
     public static class TestBean {
         private String foo;
         private String bar = "x";
@@ -67,6 +71,14 @@ public class TestBeanMap extends net.sf.cglib.CodeGenTestCase {
     public void testBeanMap() {
         TestBean bean = new TestBean();
         BeanMap map = BeanMap.create(bean);
+        BeanMap map2 = BeanMap.create(bean);
+        assertEquals("BeanMap.create should use exactly the same bean class when called multiple times",
+                map.getClass(), map2.getClass()
+        );
+        BeanMap map3 = BeanMap.create(new TestBean2());
+        assertNotSame("BeanMap.create should use different classes for different beans",
+                map.getClass(), map3.getClass()
+        );
         assertTrue(map.size() == 6);
         assertTrue(map.get("foo") == null);
         map.put("foo", "FOO");

--- a/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
@@ -35,6 +35,7 @@ import net.sf.cglib.core.AbstractClassGenerator;
 import net.sf.cglib.core.DefaultNamingPolicy;
 import net.sf.cglib.core.ReflectUtils;
 import net.sf.cglib.reflect.FastClass;
+import org.objectweb.asm.Type;
 
 /**
  *@author     Juozas Baliuka <a href="mailto:baliuka@mwm.lt">
@@ -142,10 +143,17 @@ public class TestEnhancer extends CodeGenTestCase {
         obj.setName("herby");
         EA proxy = (EA)Enhancer.create( EA.class,  new DelegateInterceptor(save) );
      
-        assertTrue(proxy.getName().equals("herby"));
+        assertEquals("proxy.getName()", "herby", proxy.getName());
 
         Factory factory = (Factory)proxy;
-        assertTrue(((EA)factory.newInstance(factory.getCallbacks())).getName().equals("herby"));
+        assertEquals("((EA)factory.newInstance(factory.getCallbacks())).getName()", "herby", ((EA)factory.newInstance(factory.getCallbacks())).getName());
+
+        Enhancer e = new Enhancer();
+        e.setSuperclass(EA.class);
+        e.setCallbackType(MethodInterceptor.class);
+        Factory factory1 = e.createFactory();
+        assertEquals("((EA)e.createFactory().newInstance(factory.getCallbacks())).getName()",
+                "herby", ((EA)factory1.newInstance(new DelegateInterceptor(save))).getName());
     }
 
     class DelegateInterceptor implements MethodInterceptor {
@@ -651,7 +659,7 @@ public class TestEnhancer extends CodeGenTestCase {
         Object instance = enhancer.create();
 
         assertTrue(instance instanceof ClassOnlyX);
-        assertTrue(instance.getClass().equals(type));
+        assertEquals("types of enhancer.createClass() and enhancer.create().getClass() should match", type, instance.getClass());
     }
 
      public void testSql() {

--- a/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
@@ -15,7 +15,11 @@
  */
 package net.sf.cglib.proxy;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -27,6 +31,7 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import net.sf.cglib.CodeGenTestCase;
+import net.sf.cglib.core.AbstractClassGenerator;
 import net.sf.cglib.core.DefaultNamingPolicy;
 import net.sf.cglib.core.ReflectUtils;
 import net.sf.cglib.reflect.FastClass;
@@ -241,6 +246,87 @@ public class TestEnhancer extends CodeGenTestCase {
         assertTrue("Custom classLoader", source.getClass().getClassLoader() == custom  );
         
         
+    }
+
+    /**
+     * Verifies that the cache in {@link AbstractClassGenerator} SOURCE doesn't
+     * leak class definitions of classloaders that are no longer used.
+     */
+    public void testSourceCleanAfterClassLoaderDispose() throws Throwable {
+        ClassLoader custom = new ClassLoader(this.getClass().getClassLoader()) {
+
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                if (EA.class.getName().equals(name)) {
+                    InputStream classStream = this.getClass().getResourceAsStream("/net/sf/cglib/proxy/EA.class");
+                    byte[] classBytes;
+                    try {
+                        classBytes = toByteArray(classStream);
+                        return this.defineClass(null, classBytes, 0, classBytes.length);
+                    } catch (IOException e) {
+                        return super.loadClass(name);
+                    }
+                } else {
+                    return super.loadClass(name);
+                }
+            }
+        };
+
+        PhantomReference<ClassLoader> clRef = new PhantomReference<ClassLoader>(custom,
+                new ReferenceQueue<ClassLoader>());
+
+        buildAdvised(custom);
+        custom = null;
+
+        for (int i = 0; i < 10; ++i) {
+            System.gc();
+            Thread.sleep(100);
+            if (clRef.isEnqueued()) {
+                break;
+            }
+        }
+        assertTrue("CGLIB should allow classloaders to be evicted. PhantomReference<ClassLoader> was not cleared after 10 gc cycles," +
+                "thus it is likely some cache is preventing the class loader to be garbage collected", clRef.isEnqueued());
+
+    }
+
+    protected Object buildAdvised(ClassLoader custom)
+            throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+        final Class<?> eaClassFromCustomClassloader = custom.loadClass(EA.class.getName());
+
+        CallbackFilter callbackFilter = new CallbackFilter() {
+            Object advised = eaClassFromCustomClassloader.newInstance();
+
+            public int accept(Method method) {
+                return 0;
+            }
+
+        };
+
+        Object source = enhance(eaClassFromCustomClassloader, null, callbackFilter, TEST_INTERCEPTOR, custom);
+        Object source2 = enhance(eaClassFromCustomClassloader, null, callbackFilter, TEST_INTERCEPTOR, custom);
+        assertEquals("enhance should return cached Enhancer when calling with same parameters",
+                source.getClass(), source2.getClass()
+        );
+        Object source3 = enhance(eaClassFromCustomClassloader, null, null, TEST_INTERCEPTOR, custom);
+        assertNotSame("enhance should return different instance when callbackFilter differs",
+                source.getClass(), source3.getClass()
+        );
+
+        return source;
+    }
+
+    private static byte[] toByteArray(InputStream input) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        int n = 0;
+
+        while (-1 != (n = input.read(buffer))) {
+            output.write(buffer, 0, n);
+        }
+
+        return output.toByteArray();
+
     }
 
     public void testRuntimException()throws Throwable{
@@ -483,6 +569,16 @@ public class TestEnhancer extends CodeGenTestCase {
         Enhancer e = new Enhancer();
         e.setSuperclass(cls);
         e.setInterfaces(interfaces);
+        e.setCallback(callback);
+        e.setClassLoader(loader);
+        return e.create();
+    }
+
+    public static Object enhance(Class cls, Class interfaces[], CallbackFilter callbackFilter, Callback callback, ClassLoader loader) {
+        Enhancer e = new Enhancer();
+        e.setSuperclass(cls);
+        e.setInterfaces(interfaces);
+        e.setCallbackFilter(callbackFilter);
         e.setCallback(callback);
         e.setClassLoader(loader);
         return e.create();

--- a/cglib/src/test/java/net/sf/cglib/proxy/TestMixin.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestMixin.java
@@ -35,6 +35,14 @@ public class TestMixin extends CodeGenTestCase {
 
     public void testDetermineInterfaces() throws Exception {
         Object obj = Mixin.create(new Object[]{ new D1(), new D2() });
+        Object obj2 = Mixin.create(new Object[]{ new D1(), new D2() });
+        assertEquals("Mixin.create should use exactly the same class when called with same parameters",
+                obj.getClass(), obj2.getClass()
+        );
+        Object obj3 = Mixin.create(new Object[]{ new D1(), new D4() });
+        assertNotSame("Mixin.create should use different classes for different parameters",
+                obj.getClass(), obj3.getClass()
+        );
         assertTrue(((DI1)obj).herby().equals("D1"));
         assertTrue(((DI2)obj).derby().equals("D2"));
     }

--- a/cglib/src/test/java/net/sf/cglib/reflect/TestFastClass.java
+++ b/cglib/src/test/java/net/sf/cglib/reflect/TestFastClass.java
@@ -70,22 +70,22 @@ public class TestFastClass extends net.sf.cglib.CodeGenTestCase {
     public void testComplex() throws Throwable {
         FastClass fc = FastClass.create(MemberSwitchBean.class);
         MemberSwitchBean bean = (MemberSwitchBean)fc.newInstance();
-        assertTrue(bean.init == 0);
-        assertTrue(fc.getName().equals("net.sf.cglib.reflect.MemberSwitchBean"));
-        assertTrue(fc.getJavaClass() == MemberSwitchBean.class);
-        assertTrue(fc.getMaxIndex() == 19);
+        assertEquals("bean.init", 0, bean.init);
+        assertEquals("fc.getName()", "net.sf.cglib.reflect.MemberSwitchBean", fc.getName());
+        assertEquals("fc.getJavaClass()", MemberSwitchBean.class, fc.getJavaClass());
+        assertEquals("fc.getMaxIndex()", 13, fc.getMaxIndex());
 
-        Constructor c1 = MemberSwitchBean.class.getConstructor(new Class[0]);
+        Constructor c1 = MemberSwitchBean.class.getConstructor();
         FastConstructor fc1 = fc.getConstructor(c1);
-        assertTrue(((MemberSwitchBean)fc1.newInstance()).init == 0);
-        assertTrue(fc1.toString().equals("public net.sf.cglib.reflect.MemberSwitchBean()"));
+        assertEquals("((MemberSwitchBean)fc1.newInstance()).init", 0, ((MemberSwitchBean)fc1.newInstance()).init);
+        assertEquals("fc1.toString()", "public net.sf.cglib.reflect.MemberSwitchBean()", fc1.toString());
 
-        Method m1 = MemberSwitchBean.class.getMethod("foo", new Class[]{ Integer.TYPE, String.class });
-        assertTrue(fc.getMethod(m1).invoke(bean, new Object[]{ new Integer(0), "" }).equals(new Integer(6)));
+        Method m1 = MemberSwitchBean.class.getMethod("foo", Integer.TYPE, String.class);
+        assertEquals("fc.getMethod(m1).invoke(bean, new Object[]{ new Integer(0), \"\" })", 6, fc.getMethod(m1).invoke(bean, new Object[]{0, ""}));
 
         // TODO: should null be allowed here?
         Method m2 = MemberSwitchBean.class.getDeclaredMethod("pkg", (Class[])null);
-        assertTrue(fc.getMethod(m2).invoke(bean, null).equals(new Integer(9)));
+        assertEquals("fc.getMethod(m2).invoke(bean, null)", 9, fc.getMethod(m2).invoke(bean, null));
     }
 
     public void testStatic() throws Throwable {

--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,27 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.17</version>
+                    <configuration>
+                        <systemProperties>
+                            <property>
+                                <name>net.sf.cglib.test.stressHashCodes</name>
+                                <value>true</value>
+                            </property>
+                        </systemProperties>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>2.17</version>
+                    <configuration>
+                        <systemProperties>
+                            <property>
+                                <name>net.sf.cglib.test.stressHashCodes</name>
+                                <value>true</value>
+                            </property>
+                        </systemProperties>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This fix removes `synchronization` in case relevant class is already cached.

The change comes on top of "fix permgen" (it reuses `WeakIdentityKey`)

Measurements (java 1.8u60, i7-4960HQ CPU @ 2.60GHz):

# 1 Thread

Response time is 15 times better.
Heap allocation is 5 times less.

Before:
```
Benchmark                                       Mode  Cnt     Score     Error   Units
BeansBenchmark.newInstance                      avgt    5  2135,987 ± 262,118   ns/op
BeansBenchmark.newInstance:·gc.alloc.rate.norm  avgt    5  1240,021 ±   0,168    B/op

```

After:
```
Benchmark                                       Mode  Cnt     Score     Error   Units
BeansBenchmark.newInstance                      avgt    5   142,438 ±   8,209   ns/op
BeansBenchmark.newInstance:·gc.alloc.rate.norm  avgt    5   256,001 ±   0,012    B/op
```

# Multiple threads

Good scalability in range of 1-2-4 threads.
Degradation after 4 is somewhat expected as the machine has just 4 hw cores.

Before:
```
Benchmark                   Mode Thr Cnt      Score      Error   Unit
BeansBenchmark.newInstance  avgt   1   5   2518,232 ±  148,755  ns/op
BeansBenchmark.newInstance  avgt   2   5   3207,201 ±  231,017  ns/op
BeansBenchmark.newInstance  avgt   4   5   7842,192 ±  528,633  ns/op
BeansBenchmark.newInstance  avgt   8   5  16380,357 ±  941,975  ns/op
```

After:
```
Benchmark                   Mode Thr Cnt      Score      Error   Unit
BeansBenchmark.newInstance  avgt   1   5    143,228 ±   15,594  ns/op
BeansBenchmark.newInstance  avgt   2   5    161,668 ±    2,057  ns/op
BeansBenchmark.newInstance  avgt   4   5    152,933 ±    2,753  ns/op
BeansBenchmark.newInstance  avgt   6   5    242,031 ±   42,862  ns/op
BeansBenchmark.newInstance  avgt   8   5    298,683 ±   39,506  ns/op
```
