### PR TITLE
Avoid PermGen leak

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/beans/ImmutableBean.java
+++ b/cglib/src/main/java/net/sf/cglib/beans/ImmutableBean.java
@@ -70,6 +70,11 @@ public class ImmutableBean
             return super.create(name);
         }
 
+        @Override
+        protected String flattenKey(Object key) {
+            return (String) key;
+        }
+
         public void generateClass(ClassVisitor v) {
             Type targetType = Type.getType(target);
             ClassEmitter ce = new ClassEmitter(v);

--- a/cglib/src/main/java/net/sf/cglib/core/AbstractClassGenerator.java
+++ b/cglib/src/main/java/net/sf/cglib/core/AbstractClassGenerator.java
@@ -211,7 +211,7 @@ implements ClassGenerator
                     cache2.put(NAME_KEY, new HashSet());
                     source.cache.put(loader, cache2);
                 } else if (useCache) {
-                    Reference ref = (Reference)cache2.get(key);
+                    Reference ref = (Reference) cache2.get(flattenKey(key));
                     gen = (Class) (( ref == null ) ? null : ref.get()); 
                 }
                 if (gen == null) {
@@ -239,7 +239,7 @@ implements ClassGenerator
                         }
                        
                         if (useCache) {
-                            cache2.put(key, new WeakReference(gen));
+                            cache2.put(flattenKey(key), new WeakReference(gen));
                         }
                         return firstInstance(gen);
                     } finally {
@@ -255,6 +255,20 @@ implements ClassGenerator
         } catch (Exception e) {
             throw new CodeGenerationException(e);
         }
+    }
+
+    /**
+     * Most key implementations hold references to the callbacks of the
+     * generated class that may hold references to whatever the callback needs
+     * to work. Those references in the callback being referenced by the key
+     * would prevent those classes from being unloaded and its ClassLoader
+     * garbage collected.
+     * <p/>
+     * By flattening the key to a string representation and not using it for
+     * anything else these unwanted references are kept away from the cache.
+     */
+    protected Object flattenKey(Object key) {
+        return key.toString();
     }
 
     abstract protected Object firstInstance(Class type) throws Exception;

--- a/cglib/src/main/java/net/sf/cglib/core/DefaultNamingPolicy.java
+++ b/cglib/src/main/java/net/sf/cglib/core/DefaultNamingPolicy.java
@@ -29,7 +29,12 @@ import java.util.Set;
  */
 public class DefaultNamingPolicy implements NamingPolicy {
     public static final DefaultNamingPolicy INSTANCE = new DefaultNamingPolicy();
-    
+
+    /**
+     * This allows to test collisions of {@code key.hashCode()}.
+     */
+    private final static boolean STRESS_HASH_CODE = Boolean.getBoolean("net.sf.cglib.test.stressHashCodes");
+	
     public String getClassName(String prefix, String source, Object key, Predicate names) {
         if (prefix == null) {
             prefix = "net.sf.cglib.empty.Object";
@@ -40,7 +45,7 @@ public class DefaultNamingPolicy implements NamingPolicy {
             prefix + "$$" + 
             source.substring(source.lastIndexOf('.') + 1) +
             getTag() + "$$" +
-            Integer.toHexString(key.hashCode());
+            Integer.toHexString(STRESS_HASH_CODE ? 0 : key.hashCode());
         String attempt = base;
         int index = 2;
         while (names.evaluate(attempt))

--- a/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
+++ b/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
@@ -149,6 +149,11 @@ abstract public class KeyFactory {
             return (KeyFactory)super.create(keyInterface.getName());
         }
 
+        @Override
+        protected String flattenKey(Object key) {
+            return (String) key;
+        }
+
         public void setHashConstant(int constant) {
             this.constant = constant;
         }

--- a/cglib/src/main/java/net/sf/cglib/proxy/InterfaceMaker.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/InterfaceMaker.java
@@ -86,6 +86,11 @@ public class InterfaceMaker extends AbstractClassGenerator
         return (Class)super.create(this);
     }
 
+    @Override
+    protected String flattenKey(Object key) {
+        return key.toString();
+    }
+
     protected ClassLoader getDefaultClassLoader() {
         return null;
     }

--- a/cglib/src/main/java/net/sf/cglib/reflect/FastClass.java
+++ b/cglib/src/main/java/net/sf/cglib/reflect/FastClass.java
@@ -65,6 +65,11 @@ abstract public class FastClass
             return (FastClass)super.create(type.getName());
         }
 
+        @Override
+        protected String flattenKey(Object key) {
+            return (String) key;
+        }
+
         protected ClassLoader getDefaultClassLoader() {
             return type.getClassLoader();
         }

--- a/cglib/src/main/java/net/sf/cglib/reflect/MulticastDelegate.java
+++ b/cglib/src/main/java/net/sf/cglib/reflect/MulticastDelegate.java
@@ -98,6 +98,11 @@ abstract public class MulticastDelegate implements Cloneable {
             return (MulticastDelegate)super.create(iface.getName());
         }
 
+        @Override
+        protected String flattenKey(Object key) {
+            return (String) key;
+        }
+
         public void generateClass(ClassVisitor cv) {
             final MethodInfo method = ReflectUtils.getMethodInfo(ReflectUtils.findInterfaceMethod(iface));
 

--- a/cglib/src/test/java/net/sf/cglib/TestGenerator.java
+++ b/cglib/src/test/java/net/sf/cglib/TestGenerator.java
@@ -40,4 +40,9 @@ abstract public class TestGenerator extends AbstractClassGenerator {
     public Object create() {
         return create(new Integer(counter++));
     }
+
+    @Override
+    protected String flattenKey(Object key) {
+        return Integer.toString((Integer) key);
+    }
 }

--- a/cglib/src/test/java/net/sf/cglib/beans/TestBeanMap.java
+++ b/cglib/src/test/java/net/sf/cglib/beans/TestBeanMap.java
@@ -23,7 +23,11 @@ import java.util.*;
 import junit.framework.*;
 
 public class TestBeanMap extends net.sf.cglib.CodeGenTestCase {
-    public static class TestBean {
+    public static class TestBean2 {
+        private String foo;
+    }
+
+	public static class TestBean {
         private String foo;
         private String bar = "x";
         private String baz;
@@ -67,6 +71,14 @@ public class TestBeanMap extends net.sf.cglib.CodeGenTestCase {
     public void testBeanMap() {
         TestBean bean = new TestBean();
         BeanMap map = BeanMap.create(bean);
+        BeanMap map2 = BeanMap.create(bean);
+        assertEquals(
+                "BeanMap.create should use exactly the same bean class when called multiple times",
+                map.getClass(), map2.getClass());
+        BeanMap map3 = BeanMap.create(new TestBean2());
+        assertNotSame(
+                "BeanMap.create should use different classes for different beans",
+                map.getClass(), map3.getClass());
         assertTrue(map.size() == 6);
         assertTrue(map.get("foo") == null);
         map.put("foo", "FOO");

--- a/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
@@ -15,7 +15,11 @@
  */
 package net.sf.cglib.proxy;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -27,6 +31,7 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import net.sf.cglib.CodeGenTestCase;
+import net.sf.cglib.core.AbstractClassGenerator;
 import net.sf.cglib.core.DefaultNamingPolicy;
 import net.sf.cglib.core.ReflectUtils;
 import net.sf.cglib.reflect.FastClass;
@@ -75,6 +80,34 @@ public class TestEnhancer extends CodeGenTestCase {
         
         
         
+        assertTrue("Cache failed",vector1.getClass() == vector2.getClass());
+    }
+    
+    
+    public void testEnhanceDifferent()throws Throwable{
+        
+        java.util.Vector vector1 = (java.util.Vector)Enhancer.create(
+        java.util.Vector.class,
+        new Class[]{java.util.List.class}, TEST_INTERCEPTOR );
+        
+        java.util.Vector vector2  = (java.util.Vector)Enhancer.create(
+        java.util.Vector.class,
+        new Class[]{java.util.List.class}, new TestInterceptor(){
+            public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy) throws Throwable {
+                if("capacity".equals(method.getName())) {
+                    return -1;
+                } else {
+                    return super.intercept(obj, method, args, proxy);
+                }
+            };
+        } );
+        
+        /*
+         * The generated class is the same, only its internal state varies.
+         */
+
+        assertEquals(10, vector1.capacity());
+        assertEquals(-1, vector2.capacity());
         assertTrue("Cache failed",vector1.getClass() == vector2.getClass());
     }
     
@@ -242,6 +275,76 @@ public class TestEnhancer extends CodeGenTestCase {
         
         
     }
+
+    /**
+     * Verifies that the cache in {@link AbstractClassGenerator} SOURCE doesn't
+     * leak class definitions of classloaders that are no longer used.
+     */
+    public void testSourceCleanAfterClassLoaderDispose() throws Throwable {
+        ClassLoader custom = new ClassLoader(this.getClass().getClassLoader()) {
+
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                if (EA.class.getName().equals(name)) {
+                    InputStream classStream = this.getClass().getResourceAsStream("/net/sf/cglib/proxy/EA.class");
+                    byte[] classBytes;
+                    try {
+                        classBytes = toByteArray(classStream);
+                        return this.defineClass(null, classBytes, 0, classBytes.length);
+                    } catch (IOException e) {
+                        return super.loadClass(name);
+                    }
+                } else {
+                    return super.loadClass(name);
+                }
+            }
+        };
+
+        PhantomReference<ClassLoader> clRef = new PhantomReference<ClassLoader>(custom,
+                new ReferenceQueue<ClassLoader>());
+
+        buildAdvised(custom);
+        custom = null;
+
+        for (int i = 0; i < 10; ++i) {
+            System.gc();
+            Thread.sleep(100);
+            if (clRef.isEnqueued()) {
+                break;
+            }
+        }
+        assertTrue(clRef.isEnqueued());
+
+    }
+
+	protected Object buildAdvised(ClassLoader custom)
+	        throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+		final Class<?> eaClassFromCustomClassloader = custom.loadClass(EA.class.getName());
+
+		Object source = enhance(eaClassFromCustomClassloader, null, new CallbackFilter() {
+			Object advised = eaClassFromCustomClassloader.newInstance();
+
+			public int accept(Method method) {
+				return 0;
+			}
+
+		}, TEST_INTERCEPTOR, custom);
+
+		return source;
+	}
+
+	private static byte[] toByteArray(InputStream input) throws IOException {
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+		byte[] buffer = new byte[4096];
+		int n = 0;
+
+		while (-1 != (n = input.read(buffer))) {
+			output.write(buffer, 0, n);
+		}
+
+		return output.toByteArray();
+
+	}
 
     public void testRuntimException()throws Throwable{
     
@@ -483,6 +586,16 @@ public class TestEnhancer extends CodeGenTestCase {
         Enhancer e = new Enhancer();
         e.setSuperclass(cls);
         e.setInterfaces(interfaces);
+        e.setCallback(callback);
+        e.setClassLoader(loader);
+        return e.create();
+    }
+
+    public static Object enhance(Class cls, Class interfaces[], CallbackFilter callbackFilter, Callback callback, ClassLoader loader) {
+        Enhancer e = new Enhancer();
+        e.setSuperclass(cls);
+        e.setInterfaces(interfaces);
+        e.setCallbackFilter(callbackFilter);
         e.setCallback(callback);
         e.setClassLoader(loader);
         return e.create();

--- a/cglib/src/test/java/net/sf/cglib/proxy/TestMixin.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestMixin.java
@@ -35,7 +35,15 @@ public class TestMixin extends CodeGenTestCase {
 
     public void testDetermineInterfaces() throws Exception {
         Object obj = Mixin.create(new Object[]{ new D1(), new D2() });
-        assertTrue(((DI1)obj).herby().equals("D1"));
+        Object obj2 = Mixin.create(new Object[] { new D1(), new D2() });
+        assertEquals(
+                "Mixin.create should use exactly the same class when called with same parameters",
+                obj.getClass(), obj2.getClass());
+        Object obj3 = Mixin.create(new Object[] { new D1(), new D4() });
+        assertNotSame(
+                "Mixin.create should use different classes for different parameters",
+                obj.getClass(), obj3.getClass());
+        assertTrue(((DI1) obj).herby().equals("D1"));
         assertTrue(((DI2)obj).derby().equals("D2"));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,27 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.17</version>
+                    <configuration>
+                        <systemProperties>
+                            <property>
+                                <name>net.sf.cglib.test.stressHashCodes</name>
+                                <value>true</value>
+                            </property>
+                        </systemProperties>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>2.17</version>
+                    <configuration>
+                        <systemProperties>
+                            <property>
+                                <name>net.sf.cglib.test.stressHashCodes</name>
+                                <value>true</value>
+                            </property>
+                        </systemProperties>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The key object put in the cache may be an instance of a dynamically generated class that references an application classloader. That reference causes said classloader to not be available for garbage collection, thus leaking the PermGen with old classes when that classloader is not needed anymore. This is mostly experienced in application restart scenarios, where each application has its own classloader managed in a long-lived container.

Attached is an exceprt from a heap dump that shoes the reference to the classloader that causes the issue:

![screen shot 2015-11-10 at 11 00 50 am](https://cloud.githubusercontent.com/assets/8010105/11064311/3a39b5ea-879b-11e5-8449-88ea4d06bdff.png)

This is a rework of https://github.com/cglib/cglib/pull/49
Icludes the tests added in https://github.com/cglib/cglib/pull/50

The change is essentially flattening the key ised in the cache to a string, which contains the fully qualified types of the defined classes.