### PR TITLE
Floating point numbers should not be tested for equality

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/CodeEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/core/CodeEmitter.java
@@ -15,9 +15,12 @@
  */
 package net.sf.cglib.core;
 
-import java.io.*;
 import java.util.*;
+
 import org.objectweb.asm.*;
+
+import static net.sf.cglib.util.ApproximateNumberEqual.doubleEquals;
+import static net.sf.cglib.util.ApproximateNumberEqual.floatEquals;
 
 /**
  * @author Juozas Baliuka, Chris Nokleberg
@@ -318,14 +321,14 @@ public class CodeEmitter extends LocalVariablesSorter {
     }
     
     public void push(float value) {
-        if (value == 0f || value == 1f || value == 2f) {
+        if (floatEquals(value, 0f) || floatEquals(value, 1f) || floatEquals(value, 2f)) {
             mv.visitInsn(TypeUtils.FCONST(value));
         } else {
             mv.visitLdcInsn(new Float(value));
         }
     }
     public void push(double value) {
-        if (value == 0d || value == 1d) {
+        if (doubleEquals(value, 0) || doubleEquals(value, 1)) {
             mv.visitInsn(TypeUtils.DCONST(value));
         } else {
             mv.visitLdcInsn(new Double(value));

--- a/cglib/src/main/java/net/sf/cglib/core/TypeUtils.java
+++ b/cglib/src/main/java/net/sf/cglib/core/TypeUtils.java
@@ -18,6 +18,9 @@ package net.sf.cglib.core;
 import java.util.*;
 import org.objectweb.asm.Type;
 
+import static net.sf.cglib.util.ApproximateNumberEqual.doubleEquals;
+import static net.sf.cglib.util.ApproximateNumberEqual.floatEquals;
+
 public class TypeUtils {
     private static final Map transforms = new HashMap();
     private static final Map rtransforms = new HashMap();
@@ -356,11 +359,11 @@ public class TypeUtils {
     }
 
     public static int FCONST(float value) {
-        if (value == 0f) {
+        if (floatEquals(value, 0f)) {
             return Constants.FCONST_0;
-        } else if (value == 1f) {
+        } else if (floatEquals(value, 1f)) {
             return Constants.FCONST_1;
-        } else if (value == 2f) {
+        } else if (floatEquals(value, 2f)) {
             return Constants.FCONST_2;
         } else {
             return -1; // error
@@ -368,9 +371,9 @@ public class TypeUtils {
     }
 
     public static int DCONST(double value) {
-        if (value == 0d) {
+        if (doubleEquals(value, 0)) {
             return Constants.DCONST_0;
-        } else if (value == 1d) {
+        } else if (doubleEquals(value, 1)) {
             return Constants.DCONST_1;
         } else {
             return -1; // error

--- a/cglib/src/main/java/net/sf/cglib/util/ApproximateNumberEqual.java
+++ b/cglib/src/main/java/net/sf/cglib/util/ApproximateNumberEqual.java
@@ -1,0 +1,20 @@
+package net.sf.cglib.util;
+
+/**
+ * Created by Ayman Elkfrawy on 6/15/2016.
+ */
+public class ApproximateNumberEqual {
+
+    public static final double EPSILON = 0.00000001;
+
+    private ApproximateNumberEqual() {
+    }
+
+    public static boolean floatEquals(float n1, float n2) {
+        return Math.abs(n1 - n2) <= EPSILON;
+    }
+
+    public static boolean doubleEquals(double n1, double n2) {
+        return Math.abs(n1 - n2) <= EPSILON;
+    }
+}

--- a/cglib/src/main/java/net/sf/cglib/util/ParallelSorter.java
+++ b/cglib/src/main/java/net/sf/cglib/util/ParallelSorter.java
@@ -19,9 +19,6 @@ import java.util.Comparator;
 import net.sf.cglib.core.*;
 import org.objectweb.asm.ClassVisitor;
 
-import static net.sf.cglib.util.ApproximateNumberEqual.doubleEquals;
-import static net.sf.cglib.util.ApproximateNumberEqual.floatEquals;
-
 /**
  * For the efficient sorting of multiple arrays in parallel.
  * <p>
@@ -226,7 +223,7 @@ abstract public class ParallelSorter extends SorterTemplate {
         public int compare(int i, int j) {
             float vi = a[i];
             float vj = a[j];
-            return (floatEquals(vi, vj)) ? 0 : (vi > vj) ? 1 : -1;
+            return Float.compare(vi, vj);
         }
     }
     
@@ -236,7 +233,7 @@ abstract public class ParallelSorter extends SorterTemplate {
         public int compare(int i, int j) {
             double vi = a[i];
             double vj = a[j];
-            return (doubleEquals(vi, vj)) ? 0 : (vi > vj) ? 1 : -1;
+            return Double.compare(vi, vj);
         }
     }
 

--- a/cglib/src/main/java/net/sf/cglib/util/ParallelSorter.java
+++ b/cglib/src/main/java/net/sf/cglib/util/ParallelSorter.java
@@ -15,10 +15,12 @@
  */
 package net.sf.cglib.util;
 
-import java.lang.reflect.*;
 import java.util.Comparator;
 import net.sf.cglib.core.*;
 import org.objectweb.asm.ClassVisitor;
+
+import static net.sf.cglib.util.ApproximateNumberEqual.doubleEquals;
+import static net.sf.cglib.util.ApproximateNumberEqual.floatEquals;
 
 /**
  * For the efficient sorting of multiple arrays in parallel.
@@ -224,7 +226,7 @@ abstract public class ParallelSorter extends SorterTemplate {
         public int compare(int i, int j) {
             float vi = a[i];
             float vj = a[j];
-            return (vi == vj) ? 0 : (vi > vj) ? 1 : -1;
+            return (floatEquals(vi, vj)) ? 0 : (vi > vj) ? 1 : -1;
         }
     }
     
@@ -234,7 +236,7 @@ abstract public class ParallelSorter extends SorterTemplate {
         public int compare(int i, int j) {
             double vi = a[i];
             double vj = a[j];
-            return (vi == vj) ? 0 : (vi > vj) ? 1 : -1;
+            return (doubleEquals(vi, vj)) ? 0 : (vi > vj) ? 1 : -1;
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1244 - “Floating point numbers should not be tested for equality”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1244
 Please let me know if you have any questions.
 Ayman Elkfrawy.