### PR TITLE
Fix regression & bugs

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/AbstractClassGenerator.java
+++ b/cglib/src/main/java/net/sf/cglib/core/AbstractClassGenerator.java
@@ -305,7 +305,7 @@ implements ClassGenerator
                         getClassName() + ". It seems that the loader has been expired from a weak reference somehow. " +
                         "Please file an issue at cglib's issue tracker.");
             }
-            synchronized(data) {
+            synchronized (classLoader) {
               String name = generateClassName(data.getUniqueNamePredicate());              
               data.reserveName(name);
               this.setClassName(name);

--- a/cglib/src/main/java/net/sf/cglib/core/AbstractClassGenerator.java
+++ b/cglib/src/main/java/net/sf/cglib/core/AbstractClassGenerator.java
@@ -22,9 +22,9 @@ import org.objectweb.asm.ClassReader;
 import java.lang.ref.WeakReference;
 import java.security.ProtectionDomain;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.WeakHashMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * Abstract class for all code-generating CGLIB utilities.
@@ -58,13 +58,13 @@ implements ClassGenerator
     private boolean attemptLoad;
 
     protected static class ClassLoaderData {
-        private final ConcurrentMap<String, Boolean> reservedClassNames = new ConcurrentHashMap<String, Boolean>(1, 0.75f, 1);
+        private final Set<String> reservedClassNames = new HashSet<String>();
         private final LoadingCache<AbstractClassGenerator, Object, Object> generatedClasses;
         private final WeakReference<ClassLoader> classLoader;
 
         private final Predicate uniqueNamePredicate = new Predicate() {
-            public boolean evaluate(Object arg) {
-                return allocateName((String) arg);
+            public boolean evaluate(Object name) {
+                return reservedClassNames.contains(name);
             }
         };
 
@@ -93,8 +93,8 @@ implements ClassGenerator
             return classLoader.get();
         }
 
-        public boolean allocateName(String name) {
-            return reservedClassNames.putIfAbsent(name, true) != null;
+        public void reserveName(String name) {
+            reservedClassNames.add(name);
         }
 
         public Predicate getUniqueNamePredicate() {
@@ -269,6 +269,7 @@ implements ClassGenerator
             ClassLoaderData data = cache.get(loader);
             if (data == null) {
                 synchronized (AbstractClassGenerator.class) {
+                    cache = CACHE;
                     data = cache.get(loader);
                     if (data == null) {
                         Map<ClassLoader, ClassLoaderData> newCache = new WeakHashMap<ClassLoader, ClassLoaderData>(cache);
@@ -304,7 +305,11 @@ implements ClassGenerator
                         getClassName() + ". It seems that the loader has been expired from a weak reference somehow. " +
                         "Please file an issue at cglib's issue tracker.");
             }
-            this.setClassName(generateClassName(data.getUniqueNamePredicate()));
+            synchronized(data) {
+              String name = generateClassName(data.getUniqueNamePredicate());              
+              data.reserveName(name);
+              this.setClassName(name);
+            }
             if (attemptLoad) {
                 try {
                     gen = classLoader.loadClass(getClassName());

--- a/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
@@ -641,28 +641,27 @@ public class TestEnhancer extends CodeGenTestCase {
     
     public void testBadNamingPolicyStillReservesNames() throws Throwable {
       Enhancer e = new Enhancer();
-      e.setSuperclass(NamingPolicyDummy.class);
       e.setUseCache(false);
-      e.setUseFactory(false);
+      e.setCallback(NoOp.INSTANCE);
+      e.setClassLoader(new ClassLoader(this.getClass().getClassLoader()){});
       e.setNamingPolicy(new NamingPolicy() {      
         public String getClassName(String prefix, String source, Object key, Predicate names) {
-          return prefix + "$ByDerby";
+          return "net.sf.cglib.empty.Object$$ByDerby$$123";
         }
       });
-      e.setCallbackType(MethodInterceptor.class);
-      Class proxied = e.createClass();
+      Class proxied = e.create().getClass();
       final String name = proxied.getCanonicalName();
       final boolean[] ran = new boolean[1];
       e.setNamingPolicy(new NamingPolicy() {
         public String getClassName(String prefix, String source, Object key, Predicate names) {
           ran[0] = true;
           assertTrue(names.evaluate(name));
-          return name + "42"; 
+          return name + "45"; 
         }
       });
-      Class proxied2 = e.createClass();
+      Class proxied2 = e.create().getClass();
       assertTrue(ran[0]);
-      assertEquals(name + "42", proxied2.getCanonicalName());
+      assertEquals(name + "45", proxied2.getCanonicalName());
     }
 
     public static Object enhance(Class cls, Class interfaces[], Callback callback, ClassLoader loader) {


### PR DESCRIPTION
1) Ensure that NamingPolicies that doesn't check the predicate still get their names reserved.
2) Fix the double-checked locking when looking up cached ClassLoaderData, otherwise we lose reserved names & generation data and lead to duplicating classes accidentally (if multiple threads try to create subclasses for a single classloader at the same time).