### PR TITLE
Instantiate proxy classes via reflection, remove Enhancer.createFactory

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/ReflectUtils.java
+++ b/cglib/src/main/java/net/sf/cglib/core/ReflectUtils.java
@@ -241,7 +241,9 @@ public class ReflectUtils {
             
         boolean flag = cstruct.isAccessible();
         try {
-            cstruct.setAccessible(true);
+            if (!flag) {
+                cstruct.setAccessible(true);
+            }
             Object result = cstruct.newInstance(args);
             return result;
         } catch (InstantiationException e) {
@@ -251,7 +253,9 @@ public class ReflectUtils {
         } catch (InvocationTargetException e) {
             throw new CodeGenerationException(e.getTargetException());
         } finally {
-            cstruct.setAccessible(flag);
+            if (!flag) {
+                cstruct.setAccessible(flag);
+            }
         }
                 
     }

--- a/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
@@ -657,6 +657,26 @@ public class TestEnhancer extends CodeGenTestCase {
       assertEquals(name + "45", proxied2.getCanonicalName());
     }
 
+    /**
+     * In theory, every sane implementation of {@link NamingPolicy} should check if the class name is occupied,
+     * however, in practice there are implementations in the wild that just return whatever they feel is good.
+     *
+     * @throws Throwable if something wrong happens
+     */
+    public void testNamingPolicyThatReturnsConstantNames() throws Throwable {
+      Enhancer e = new Enhancer();
+      final String desiredClassName = "net.sf.cglib.empty.Object$$42";
+      e.setCallback(NoOp.INSTANCE);
+      e.setClassLoader(new ClassLoader(this.getClass().getClassLoader()){});
+      e.setNamingPolicy(new NamingPolicy() {
+        public String getClassName(String prefix, String source, Object key, Predicate names) {
+          return desiredClassName;
+        }
+      });
+      Class proxied = e.create().getClass();
+      assertEquals("Class name should match the one returned by NamingPolicy", desiredClassName, proxied.getName());
+    }
+
     public static Object enhance(Class cls, Class interfaces[], Callback callback, ClassLoader loader) {
         Enhancer e = new Enhancer();
         e.setSuperclass(cls);

--- a/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
@@ -161,13 +161,6 @@ public class TestEnhancer extends CodeGenTestCase {
 
         Factory factory = (Factory)proxy;
         assertEquals("((EA)factory.newInstance(factory.getCallbacks())).getName()", "herby", ((EA)factory.newInstance(factory.getCallbacks())).getName());
-
-        Enhancer e = new Enhancer();
-        e.setSuperclass(EA.class);
-        e.setCallbackType(MethodInterceptor.class);
-        Factory factory1 = e.createFactory();
-        assertEquals("((EA)e.createFactory().newInstance(factory.getCallbacks())).getName()",
-                "herby", ((EA)factory1.newInstance(new DelegateInterceptor(save))).getName());
     }
 
     class DelegateInterceptor implements MethodInterceptor {


### PR DESCRIPTION
Here's alternative approach to class instantiation (this PR is alternative to #79).

Note: the same generated class might be used with different constructors later, thus there should be something like an inline cache (otherwise it will end up with some kind of search for the proper constructor).

Here I implement 1-entry inline cache (== remember just one constructor for the class, and use it).
If user uses more than one constructor per proxy, the code falls back to `ReflectionUtils.newInstance(...)`, and it will be rather slow: https://github.com/cglib/cglib/pull/82/files#diff-173a9c4b512f39086ed564b6320318e2R422

The results are as follows:

# Before

```
1.7u55, factory
Benchmark                                                    Mode  Cnt     Score    Error   Units
BeansBenchmark.newInstance                                   avgt   10   201,222 ±  3,494   ns/op
BeansBenchmark.newInstance:·gc.alloc.rate                    avgt   10  1251,090 ± 21,714  MB/sec
BeansBenchmark.newInstance:·gc.alloc.rate.norm               avgt   10   264,000 ±  0,001    B/op

1.8u60, factory
Benchmark                                                    Mode  Cnt     Score    Error   Units
BeansBenchmark.newInstance                                   avgt   10   146,819 ±  2,805   ns/op
BeansBenchmark.newInstance:·gc.alloc.rate.norm               avgt   10   264,000 ±  0,001    B/op
```


# After

NOTE: the results are for happy-case scenario (i.e. just one constructor is used)
Otherwise the code falls back to old `getDeclaredConstructor` path: https://github.com/cglib/cglib/pull/82/files#diff-173a9c4b512f39086ed564b6320318e2R422

```
1.7u55, reflection
Benchmark                                                    Mode  Cnt     Score    Error   Units
BeansBenchmark.newInstance                                   avgt   10   208,021 ±  6,498   ns/op
BeansBenchmark.newInstance:·gc.alloc.rate.norm               avgt   10   256,000 ±  0,001    B/op

1.8u60, reflection
Benchmark                                                    Mode  Cnt     Score    Error   Units
BeansBenchmark.newInstance                                   avgt   10   162,185 ±  3,051   ns/op
BeansBenchmark.newInstance:·gc.alloc.rate.norm               avgt   10   256,000 ±  0,001    B/op
```

closes #75