### PR TITLE
Add JDK9 Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,33 @@
+sudo: false
 language: java
-jdk:
-  - oraclejdk8
-  - openjdk7
-  - openjdk6
+before_script:
+  - echo "MAVEN_OPTS='-Xmx512m -Dgpg.skip=true'" > ~/.mavenrc
+  - if [[ "x$JDK" == *'x9'* ]]; then remove_dir_from_path $JAVA_HOME/bin; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; export PATH=$JAVA_HOME/bin:$PATH; java -Xmx32m -version; fi
+
+cache:
+  directories:
+    - '$HOME/.m2/repository'
+
+before_cache:
+  # No sense in caching current build artifacts
+  rm -rf $HOME/.m2/repository/cglib
+
+# Skip default "mvn install" issued by Travis
+install: true
+script:
+  - mvn test -B -V
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: JDK=9
+  include:
+    - jdk: oraclejdk8
+    - jdk: oraclejdk8
+      addons:
+        apt:
+          packages:
+            - oracle-java9-installer
+      env: JDK=9
+    - jdk: openjdk7
+    - jdk: openjdk6

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 
         <java.version.source>1.5</java.version.source>
         <java.version.target>1.5</java.version.target>
+        <asm.version>5.0.4</asm.version>
         <java.compiler.argument />
 
         <java.test.compiler.argument>${java.compiler.argument}</java.test.compiler.argument>
@@ -81,6 +82,18 @@
                 <jdk>[1.8,)</jdk>
             </activation>
             <properties>
+                <java.test.compiler.argument>-parameters</java.test.compiler.argument>
+            </properties>
+        </profile>
+        <profile>
+            <id>java9</id>
+            <activation>
+                <jdk>[1.9,)</jdk>
+            </activation>
+            <properties>
+                <java.version.source>1.6</java.version.source>
+                <java.version.target>1.6</java.version.target>
+                <asm.version>6.0_ALPHA</asm.version>
                 <java.test.compiler.argument>-parameters</java.test.compiler.argument>
             </properties>
         </profile>
@@ -146,7 +159,7 @@
                         <additionalDependency>
                           <groupId>org.ow2.asm</groupId>
                           <artifactId>asm</artifactId>
-                          <version>5.0.4</version>
+                          <version>${asm.version}</version>
                         </additionalDependency>
                         <additionalDependency>
                           <groupId>org.apache.ant</groupId>
@@ -208,7 +221,7 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>5.0.4</version>
+                <version>${asm.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.ant</groupId>


### PR DESCRIPTION
I've marked jdk9 job as "allowed failure" since jdk9 tests still have failures even if using the latest ASM 6.0_ALPHA.

Differences of java 9 vs pre-java 9 build:
* source=target=1.6 (1.5 is not supported in java 9)
* ASM version == 6.0_ALPHA (for java 9 bytecode support)

There are two kind of failures:
```
testSql(net.sf.cglib.proxy.TestEnhancer)  Time elapsed: 0.001 sec  <<< ERROR!
net.sf.cglib.core.CodeGenerationException: java.lang.reflect.InvocationTargetException-->null
	at jdk.internal.loader.BuiltinClassLoader.loadClass(java.base@9-ea/BuiltinClassLoader.java:366)
	at java.lang.ClassLoader.loadClass(java.base@9-ea/ClassLoader.java:419)
	at java.lang.ClassLoader.defineClass1(java.base@9-ea/Native Method)
	at java.lang.ClassLoader.defineClass(java.base@9-ea/ClassLoader.java:942)
	at jdk.internal.reflect.GeneratedMethodAccessor25.invoke(java.base@9-ea/Unknown Source)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@9-ea/DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(java.base@9-ea/Method.java:531)
	at net.sf.cglib.core.ReflectUtils.defineClass(ReflectUtils.java:409)
	at net.sf.cglib.core.AbstractClassGenerator.generate(AbstractClassGenerator.java:336)
	at net.sf.cglib.proxy.Enhancer.generate(Enhancer.java:455)
```

and

```
testPackagePrivateMethod_bootstrapClassLoader(net.sf.cglib.reflect.TestFastClass)  Time elapsed: 0.001 sec  <<< ERROR!
java.lang.NoSuchMethodException: java.lang.String.getChars([C, int)
	at java.lang.Class.getDeclaredMethod(java.base@9-ea/Class.java:2308)
	at net.sf.cglib.reflect.TestFastClass.testPackagePrivateMethod_bootstrapClassLoader(TestFastClass.java:663)
```