### PR TITLE
Generate OSGi manifest headers

### DIFF
--- a/cglib-nodep/pom.xml
+++ b/cglib-nodep/pom.xml
@@ -16,7 +16,7 @@
     <!-- P R O J E C T  D E S C R I P T I O N -->
     <!-- ====================================================================== -->
     <artifactId>cglib-nodep</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <!-- ====================================================================== -->
     <!-- B U I L D -->
@@ -28,6 +28,7 @@
                 <artifactId>jarjar-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                    	<phase>prepare-package</phase>
                         <goals>
                             <goal>jarjar</goal>
                         </goals>
@@ -52,8 +53,19 @@
                             <pattern>net.sf.cglib.**</pattern>
                         </keep>
                     </rules>
+                    <output>${project.build.directory}/classes</output>
                 </configuration>
             </plugin>
+           	<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<configuration>
+					<instructions>
+						<Export-Package>!net.sf.cglib.asm.*,net.sf.cglib.*</Export-Package>
+						<Import-Package>!*</Import-Package>
+					</instructions>
+				</configuration>
+			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/cglib/pom.xml
+++ b/cglib/pom.xml
@@ -16,7 +16,7 @@
     <!-- P R O J E C T  D E S C R I P T I O N -->
     <!-- ====================================================================== -->
     <artifactId>cglib</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <!-- ====================================================================== -->
     <!-- B U I L D -->
@@ -35,6 +35,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
+           	<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<configuration>
+					<instructions>
+						<Export-Package>net.sf.cglib.*</Export-Package>
+						<Import-Package>!net.sf.cglib.*,*</Import-Package>
+					</instructions>
+				</configuration>
+			</plugin>
         </plugins>
 
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,12 @@
                     <artifactId>jarjar-maven-plugin</artifactId>
                     <version>1.9</version>
                 </plugin>
+                <plugin>
+    				<groupId>org.apache.felix</groupId>
+    				<artifactId>maven-bundle-plugin</artifactId>
+    				<version>3.0.1</version>
+    				<extensions>true</extensions>
+				</plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
Packaging phase for cglib-nodep and cglib uses now the
maven-bundle-plugin instead of the regular JAR plugin. This makes the
cglib a regular OSGi bundle. For non-OSGi environments, this change has
no effect.