### PR TITLE
The Ant dependency isn't optional as expected

### DIFF
--- a/cglib/pom.xml
+++ b/cglib/pom.xml
@@ -64,6 +64,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,6 @@
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
                 <version>${ant.version}</version>
-                <optional>true</optional>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Hi,

The `<optional>true</optional>` attribute of the ant dependency defined in the `dependencyManagement` section of the root pom isn't inherited by the cglib pom. The dependency isn't optional as expected. Here is a patch fixing this.
