### PR TITLE
Add checkcasts for arguments of invoked bridges

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/proxy/CallbackGenerator.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/CallbackGenerator.java
@@ -31,6 +31,6 @@ interface CallbackGenerator
         int getIndex(MethodInfo method);
         void emitCallback(CodeEmitter ce, int index);
         Signature getImplSignature(MethodInfo method);
-        void emitInvoke(CodeEmitter e, MethodInfo method);
+        void emitLoadArgsAndInvoke(CodeEmitter e, MethodInfo method);
     }
 }

--- a/cglib/src/main/java/net/sf/cglib/proxy/MethodInterceptorGenerator.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/MethodInterceptorGenerator.java
@@ -139,8 +139,7 @@ implements CallbackGenerator
             e.throw_exception(ABSTRACT_METHOD_ERROR, method.toString() + " is abstract" );
         } else {
             e.load_this();
-            e.load_args();
-            context.emitInvoke(e, method);
+            context.emitLoadArgsAndInvoke(e, method);
         }
     }
 

--- a/cglib/src/main/java/net/sf/cglib/proxy/NoOpGenerator.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/NoOpGenerator.java
@@ -32,8 +32,7 @@ implements CallbackGenerator
                     TypeUtils.isPublic(method.getModifiers()))) {
                 CodeEmitter e = EmitUtils.begin_method(ce, method);
                 e.load_this();
-                e.load_args();
-                context.emitInvoke(e, method);
+                context.emitLoadArgsAndInvoke(e, method);
                 e.return_value();
                 e.end_method();
             }


### PR DESCRIPTION
This fixes a TODO in Enhancer: the assumption that a bridge's parameters
are assignable to the target's parameters doesn't hold in certain
cross-compilation scenarios.

The included test case fails with a VerifyError if the checkcasts are
omitted.

Also, make BridgeMethodResolver use the same class loader as Enhancer to
make it easier to test.