### PR TITLE
Mark org.apache.ant:ant as optional=true

### DIFF
--- a/cglib/pom.xml
+++ b/cglib/pom.xml
@@ -64,6 +64,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
ant is not required for usage of cglib, hence should be marked as optional.
Related to https://github.com/spring-projects/spring-boot/issues/10137#issuecomment-326507911