### PR TITLE
Avoid deadlock when static initializers of the enhanced classes call cglib APIs

### DIFF
--- a/cglib/src/test/java/net/sf/cglib/TestAll.java
+++ b/cglib/src/test/java/net/sf/cglib/TestAll.java
@@ -49,6 +49,7 @@ public class TestAll extends TestCase {
         
         // proxy
         suite.addTest(TestEnhancer.suite());
+        suite.addTest(TestEnhancerDeadlock.suite());
         suite.addTest(TestProxy.suite());
         suite.addTest(TestDispatcher.suite());
         suite.addTest(TestProxyRefDispatcher.suite());

--- a/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancerDeadlock.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancerDeadlock.java
@@ -1,0 +1,45 @@
+package net.sf.cglib.proxy;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.junit.Assert;
+
+import java.lang.reflect.Method;
+
+public class TestEnhancerDeadlock extends TestCase {
+    public TestEnhancerDeadlock(String name) {
+        super(name);
+    }
+
+    public static Test suite() {
+        return new TestSuite(TestEnhancerDeadlock.class);
+    }
+
+    public void testDeadlock() {
+        EnhancedClass one =
+                (EnhancedClass) Enhancer.create(EnhancedClass.class, new MethodInterceptor() {
+                    public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy) {
+                        return "from testDeadlock";
+                    }
+                });
+
+        Assert.assertEquals("value should be intercepted as per testDeadlock", "from testDeadlock", one.test());
+        Assert.assertEquals("value should be intercepted as per static init", "from <clinit>", EnhancedClass.INSTANCE.test());
+    }
+
+
+    public static class EnhancedClass {
+        // Call cglib API from within static block to trigger deadlock in Cglib caches
+        final static EnhancedClass INSTANCE =
+                (EnhancedClass) Enhancer.create(EnhancedClass.class, new MethodInterceptor() {
+                    public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy) {
+                        return "from <clinit>";
+                    }
+                });
+
+        public String test() {
+            return "original";
+        }
+    }
+}


### PR DESCRIPTION
The workaround is to set timeout of 5 seconds for the loading cache.

The timeout can be configured via cglib.loading_cache.timeout property.

fixes #120