### PR TITLE
remove java6 support from pom & travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,4 @@ matrix:
             - oracle-java9-installer
       env: JDK=9
     - jdk: openjdk7
-    - jdk: openjdk6
-    
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
+

--- a/pom.xml
+++ b/pom.xml
@@ -83,20 +83,6 @@
     <!-- ====================================================================== -->
     <profiles>
         <profile>
-            <id>java6</id>
-            <activation>
-                <jdk>1.6</jdk>
-            </activation>
-            <properties>
-                <jmh.version>1.16</jmh.version>
-                <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
-                <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
-                <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
-                <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
-                <ant.version>1.9.11</ant.version>
-            </properties>
-        </profile>
-        <profile>
             <id>java8</id>
             <activation>
                 <jdk>[1.8,)</jdk>


### PR DESCRIPTION
maven central doesn't support java6 anymore after they updated their TLS requirements (https://blog.sonatype.com/enhancing-ssl-security-and-http/2-support-for-central).  java6 is old, we don't need to support it anymore.