### PR TITLE
Add fall-through comment to CodeEmitter

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/CodeEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/core/CodeEmitter.java
@@ -806,6 +806,7 @@ public class CodeEmitter extends LocalVariablesSorter {
                 break;
             case Type.VOID:
                 aconst_null();
+                // fall through
             default:
                 push(0);
             }


### PR DESCRIPTION
Silences an ErrorProne warning:

CodeEmitter.java:809: error: [FallThrough] Execution may fall through from the previous case; add a `// fall through` comment before this line if it was deliberate
            default:
            ^
    (see http://errorprone.info/bugpattern/FallThrough)