### PR TITLE
remove unused import statement

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/internal/CustomizerRegistry.java
+++ b/cglib/src/main/java/net/sf/cglib/core/internal/CustomizerRegistry.java
@@ -1,7 +1,6 @@
 package net.sf.cglib.core.internal;
 
 import net.sf.cglib.core.Customizer;
-import net.sf.cglib.core.FieldTypeCustomizer;
 import net.sf.cglib.core.KeyFactoryCustomizer;
 
 import java.util.*;
@@ -34,13 +33,12 @@ public class CustomizerRegistry {
         }
         return (List<T>) list;
     }
-    
+
     /**
      * @deprecated Only to keep backward compatibility.
      */
     @Deprecated
-    public static CustomizerRegistry singleton(Customizer customizer)
-    {
+    public static CustomizerRegistry singleton(Customizer customizer) {
         CustomizerRegistry registry = new CustomizerRegistry(new Class[]{Customizer.class});
         registry.add(customizer);
         return registry;


### PR DESCRIPTION
Hi, I  just format `CustomizerRegistry.java` to keep it consistent with other files.

1.  remove unused import statement;
2.  brace-on-the-same-line;
3.  remove whitespaces in empty lines;

Correct me of I am wrong. 😃 