### PR TITLE
Support ASM7_EXPERIMENTAL if system property is set

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/AsmApi.java
+++ b/cglib/src/main/java/net/sf/cglib/core/AsmApi.java
@@ -1,0 +1,33 @@
+package net.sf.cglib.core;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import org.objectweb.asm.Opcodes;
+
+final class AsmApi {
+
+    private static final String EXPERIMENTAL_ASM7_PROPERTY_NAME = "net.sf.cglib.experimental_asm7";
+
+    /**
+     * Returns the latest stable ASM API value in {@link Opcodes} unless overridden via the
+     * net.sf.cglib.experimental_asm7 property.
+     */
+    static int value() {
+        boolean experimentalAsm7;
+        try {
+            experimentalAsm7 = Boolean.parseBoolean(AccessController.doPrivileged(
+                    new PrivilegedAction<String>() {
+                        public String run() {
+                            return System.getProperty(EXPERIMENTAL_ASM7_PROPERTY_NAME);
+                        }
+                    }));
+        } catch (Exception ignored) {
+            experimentalAsm7 = false;
+        }
+        return experimentalAsm7 ? Opcodes.ASM7_EXPERIMENTAL : Opcodes.ASM6;
+    }
+
+    private AsmApi() {
+    }
+}

--- a/cglib/src/main/java/net/sf/cglib/core/Constants.java
+++ b/cglib/src/main/java/net/sf/cglib/core/Constants.java
@@ -15,7 +15,6 @@
  */
 package net.sf.cglib.core;
 
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 /**
@@ -25,7 +24,7 @@ import org.objectweb.asm.Type;
 public interface Constants extends org.objectweb.asm.Opcodes {
 
     /* Indicates the ASM API version that is used throughout cglib */
-    public static final int ASM_API = Opcodes.ASM6;
+    public static final int ASM_API = AsmApi.value();
 
     public static final Class[] EMPTY_CLASS_ARRAY = {};
     public static final Type[] TYPES_EMPTY = {};

--- a/cglib/src/test/java/net/sf/cglib/core/AsmApiTest.java
+++ b/cglib/src/test/java/net/sf/cglib/core/AsmApiTest.java
@@ -1,0 +1,42 @@
+package net.sf.cglib.core;
+
+import org.junit.Test;
+import org.objectweb.asm.Opcodes;
+
+import static org.junit.Assert.*;
+
+public class AsmApiTest {
+
+    @Test
+    public void testValue() {
+        assertEquals(Opcodes.ASM6, AsmApi.value());
+    }
+
+    @Test
+    public void testValueWithSystemPropertyTrue() {
+        int asmApi = setSystemPropertyAndGetValue("true");
+        assertEquals(Opcodes.ASM7_EXPERIMENTAL, asmApi);
+    }
+
+    @Test
+    public void testValueWithSystemPropertyEmptyString() {
+        int asmApi = setSystemPropertyAndGetValue("");
+        assertEquals(Opcodes.ASM6, asmApi);
+    }
+
+    @Test
+    public void testValueWithSystemPropertyFalse() {
+        int asmApi = setSystemPropertyAndGetValue("false");
+        assertEquals(Opcodes.ASM6, asmApi);
+    }
+
+    private int setSystemPropertyAndGetValue(String value) {
+        String propName = "net.sf.cglib.experimental_asm7";
+        System.setProperty(propName, value);
+        try {
+            return AsmApi.value();
+        } finally {
+            System.clearProperty(propName);
+        }
+    }
+}


### PR DESCRIPTION
Full support for Java 11 bytecode requires ASM7_EXPERIMENTAL. The
approach used here is similar to byte-buddy's:

https://github.com/raphw/byte-buddy/blob/30c31ab403eedce386e28acc3e6aee2a7e2e0752/byte-buddy-dep/src/main/java/net/bytebuddy/utility/OpenedClassReader.java#L42