### PR TITLE
Update to ASM 7.0-beta and default to Opcodes.ASM7

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/AsmApi.java
+++ b/cglib/src/main/java/net/sf/cglib/core/AsmApi.java
@@ -1,31 +1,14 @@
 package net.sf.cglib.core;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 import org.objectweb.asm.Opcodes;
 
 final class AsmApi {
 
-    private static final String EXPERIMENTAL_ASM7_PROPERTY_NAME = "net.sf.cglib.experimental_asm7";
-
     /**
-     * Returns the latest stable ASM API value in {@link Opcodes} unless overridden via the
-     * net.sf.cglib.experimental_asm7 property.
+     * Returns the latest stable ASM API value in {@link Opcodes}.
      */
     static int value() {
-        boolean experimentalAsm7;
-        try {
-            experimentalAsm7 = Boolean.parseBoolean(AccessController.doPrivileged(
-                    new PrivilegedAction<String>() {
-                        public String run() {
-                            return System.getProperty(EXPERIMENTAL_ASM7_PROPERTY_NAME);
-                        }
-                    }));
-        } catch (Exception ignored) {
-            experimentalAsm7 = false;
-        }
-        return experimentalAsm7 ? Opcodes.ASM7_EXPERIMENTAL : Opcodes.ASM6;
+        return Opcodes.ASM7;
     }
 
     private AsmApi() {

--- a/cglib/src/test/java/net/sf/cglib/core/AsmApiTest.java
+++ b/cglib/src/test/java/net/sf/cglib/core/AsmApiTest.java
@@ -9,28 +9,28 @@ public class AsmApiTest {
 
     @Test
     public void testValue() {
-        assertEquals(Opcodes.ASM6, AsmApi.value());
+        assertEquals(Opcodes.ASM7, AsmApi.value());
     }
 
+    /**
+     * With the release of ASM 7.0 beta, Opcodes.ASM7_EXPERIMENTAL
+     * has been replaced by Opcodes.ASM7 so we simply ignore
+     * the system property and default to the newest stable
+     * version.
+     */
     @Test
-    public void testValueWithSystemPropertyTrue() {
-        int asmApi = setSystemPropertyAndGetValue("true");
-        assertEquals(Opcodes.ASM7_EXPERIMENTAL, asmApi);
+    public void testValueWithAsm7Experimental() {
+        int asmApi = setAsm7ExperimentalAndGetValue("true");
+        assertEquals(Opcodes.ASM7, asmApi);
+
+        asmApi = setAsm7ExperimentalAndGetValue("");
+        assertEquals(Opcodes.ASM7, asmApi);
+
+        asmApi = setAsm7ExperimentalAndGetValue("false");
+        assertEquals(Opcodes.ASM7, asmApi);
     }
 
-    @Test
-    public void testValueWithSystemPropertyEmptyString() {
-        int asmApi = setSystemPropertyAndGetValue("");
-        assertEquals(Opcodes.ASM6, asmApi);
-    }
-
-    @Test
-    public void testValueWithSystemPropertyFalse() {
-        int asmApi = setSystemPropertyAndGetValue("false");
-        assertEquals(Opcodes.ASM6, asmApi);
-    }
-
-    private int setSystemPropertyAndGetValue(String value) {
+    private int setAsm7ExperimentalAndGetValue(String value) {
         String propName = "net.sf.cglib.experimental_asm7";
         System.setProperty(propName, value);
         try {

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
         <java.version.source>1.5</java.version.source>
         <java.version.target>1.5</java.version.target>
-        <asm.version>6.2.1</asm.version>
+        <asm.version>7.0-beta</asm.version>
         <ant.version>1.10.3</ant.version>
         <jmh.version>1.21</jmh.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>


### PR DESCRIPTION
Also ignore system property for using
Opcodes.ASM7_EXPERIMENTAL (which no longer exists).