### PR TITLE
Fix a no-op comparison

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/beans/BulkBeanEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/beans/BulkBeanEmitter.java
@@ -56,7 +56,7 @@ class BulkBeanEmitter extends ClassEmitter {
 
     private void generateGet(final Class target, final Method[] getters) {
         CodeEmitter e = begin_method(Constants.ACC_PUBLIC, GET_PROPERTY_VALUES, null);
-        if (getters.length >= 0) {
+        if (getters.length > 0) {
             e.load_arg(0);
             e.checkcast(Type.getType(target));
             Local bean = e.make_local();


### PR DESCRIPTION
Array lengths are always >= 0, this code was trying to test if the array
was non-empty.

The mistake was detected by
http://errorprone.info/bugpattern/SizeGreaterThanOrEqualsZero.