### PR TITLE
Treat invokeinterface bridges similarly to invokespecial

### DIFF
--- a/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
+++ b/cglib/src/test/java/net/sf/cglib/proxy/TestEnhancer.java
@@ -40,7 +40,6 @@ import net.sf.cglib.core.NamingPolicy;
 import net.sf.cglib.core.Predicate;
 import net.sf.cglib.core.ReflectUtils;
 import net.sf.cglib.reflect.FastClass;
-import org.junit.Assume;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -1429,8 +1428,10 @@ public class TestEnhancer extends CodeGenTestCase {
         //     void f(T t);
         // }
 
-        // The test relies on Java 8 bytecode for default methods.
-        Assume.assumeTrue(getMajor() >= 8);
+        if (getMajor() < 8) {
+            // The test relies on Java 8 bytecode for default methods.
+            return;
+        }
 
         final Map<String, byte[]> classes = new HashMap<String, byte[]>();
         {


### PR DESCRIPTION
In both cases we need to avoid using invokesuper. For interface bridges,
using invokesuper will fail since the method being bridged to is in a
superinterface, not a superclass.

Starting in Java 8, javac emits default bridge methods in interfaces,
which use invokeinterface to bridge to the target method.

Without this fix, the included test case fails with:

```
Caused by: java.lang.NoSuchMethodError: java.lang.Object.f(Ljava/lang/Object;)V
    at B$$EnhancerByCGLIB$$7aa3e8e0.f(<generated>)
    ... 28 more
```