### PR TITLE
Use invokestatic on static interface methods

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/CodeEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/core/CodeEmitter.java
@@ -849,10 +849,10 @@ public class CodeEmitter extends LocalVariablesSorter {
         Signature sig = method.getSignature();
         if (sig.getName().equals(Constants.CONSTRUCTOR_NAME)) {
             invoke_constructor(type, sig);
-        } else if (TypeUtils.isInterface(classInfo.getModifiers())) {
-            invoke_interface(type, sig);
         } else if (TypeUtils.isStatic(method.getModifiers())) {
             invoke_static(type, sig);
+        } else if (TypeUtils.isInterface(classInfo.getModifiers())) {
+            invoke_interface(type, sig);
         } else {
             invoke_virtual(virtualType, sig);
         }


### PR DESCRIPTION
Even though they are methods on an interface type, invokeinterface is only for instance method. This code was added >15 years ago, long before static methods were allowed on interfaces.