### PR TITLE
Fix invokestatic on interfaces in JDK 9+ and begin emitting Java 8 bytecode in FastClass to support it

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/beans/BeanCopier.java
+++ b/cglib/src/main/java/net/sf/cglib/beans/BeanCopier.java
@@ -99,7 +99,7 @@ abstract public class BeanCopier
             Type sourceType = Type.getType(source);
             Type targetType = Type.getType(target);
             ClassEmitter ce = new ClassEmitter(v);
-            ce.begin_class(Constants.V1_2,
+            ce.begin_class(Constants.V1_8,
                            Constants.ACC_PUBLIC,
                            getClassName(),
                            BEAN_COPIER,

--- a/cglib/src/main/java/net/sf/cglib/beans/BeanGenerator.java
+++ b/cglib/src/main/java/net/sf/cglib/beans/BeanGenerator.java
@@ -102,7 +102,7 @@ public class BeanGenerator extends AbstractClassGenerator
             types[i] = (Type)props.get(names[i]);
         }
         ClassEmitter ce = new ClassEmitter(v);
-        ce.begin_class(Constants.V1_2,
+        ce.begin_class(Constants.V1_8,
                        Constants.ACC_PUBLIC,
                        getClassName(),
                        superclass != null ? Type.getType(superclass) : Constants.TYPE_OBJECT,

--- a/cglib/src/main/java/net/sf/cglib/beans/BeanMapEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/beans/BeanMapEmitter.java
@@ -45,7 +45,7 @@ class BeanMapEmitter extends ClassEmitter {
     public BeanMapEmitter(ClassVisitor v, String className, Class type, int require) {
         super(v);
 
-        begin_class(Constants.V1_2, Constants.ACC_PUBLIC, className, BEAN_MAP, null, Constants.SOURCE_FILE);
+        begin_class(Constants.V1_8, Constants.ACC_PUBLIC, className, BEAN_MAP, null, Constants.SOURCE_FILE);
         EmitUtils.null_constructor(this);
         EmitUtils.factory_method(this, NEW_INSTANCE);
         generateConstructor();

--- a/cglib/src/main/java/net/sf/cglib/beans/BulkBeanEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/beans/BulkBeanEmitter.java
@@ -47,7 +47,7 @@ class BulkBeanEmitter extends ClassEmitter {
         Method[] setters = new Method[setterNames.length];
         validate(target, getterNames, setterNames, types, getters, setters);
 
-        begin_class(Constants.V1_2, Constants.ACC_PUBLIC, className, BULK_BEAN, null, Constants.SOURCE_FILE);
+        begin_class(Constants.V1_8, Constants.ACC_PUBLIC, className, BULK_BEAN, null, Constants.SOURCE_FILE);
         EmitUtils.null_constructor(this);
         generateGet(target, getters);
         generateSet(target, setters);

--- a/cglib/src/main/java/net/sf/cglib/beans/ImmutableBean.java
+++ b/cglib/src/main/java/net/sf/cglib/beans/ImmutableBean.java
@@ -73,7 +73,7 @@ public class ImmutableBean
         public void generateClass(ClassVisitor v) {
             Type targetType = Type.getType(target);
             ClassEmitter ce = new ClassEmitter(v);
-            ce.begin_class(Constants.V1_2,
+            ce.begin_class(Constants.V1_8,
                            Constants.ACC_PUBLIC,
                            getClassName(),
                            targetType,

--- a/cglib/src/main/java/net/sf/cglib/core/CodeEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/core/CodeEmitter.java
@@ -476,7 +476,7 @@ public class CodeEmitter extends LocalVariablesSorter {
     }
 
     public void super_invoke(Signature sig) {
-        emit_invoke(Constants.INVOKESPECIAL, ce.getSuperType(), sig);
+        emit_invoke(Constants.INVOKESPECIAL, ce.getSuperType(), sig, false);
     }
 
     public void invoke_constructor(Type type) {
@@ -491,7 +491,7 @@ public class CodeEmitter extends LocalVariablesSorter {
         invoke_constructor(ce.getClassType());
     }
 
-    private void emit_invoke(int opcode, Type type, Signature sig) {
+    private void emit_invoke(int opcode, Type type, Signature sig, boolean isInterface) {
         if (sig.getName().equals(Constants.CONSTRUCTOR_NAME) &&
             ((opcode == Constants.INVOKEVIRTUAL) ||
              (opcode == Constants.INVOKESTATIC))) {
@@ -501,19 +501,24 @@ public class CodeEmitter extends LocalVariablesSorter {
                            type.getInternalName(),
                            sig.getName(),
                            sig.getDescriptor(),
-                           opcode == Opcodes.INVOKEINTERFACE);
+                           isInterface);
     }
     
     public void invoke_interface(Type owner, Signature sig) {
-        emit_invoke(Constants.INVOKEINTERFACE, owner, sig);
+        emit_invoke(Constants.INVOKEINTERFACE, owner, sig, true);
     }
 
     public void invoke_virtual(Type owner, Signature sig) {
-        emit_invoke(Constants.INVOKEVIRTUAL, owner, sig);
+        emit_invoke(Constants.INVOKEVIRTUAL, owner, sig, false);
     }
 
+    @Deprecated
     public void invoke_static(Type owner, Signature sig) {
-        emit_invoke(Constants.INVOKESTATIC, owner, sig);
+        invoke_static(owner, sig, false);
+    }
+
+    public void invoke_static(Type owner, Signature sig, boolean isInterface) {
+        emit_invoke(Constants.INVOKESTATIC, owner, sig, isInterface);
     }
 
     public void invoke_virtual_this(Signature sig) {
@@ -525,7 +530,7 @@ public class CodeEmitter extends LocalVariablesSorter {
     }
 
     public void invoke_constructor(Type type, Signature sig) {
-        emit_invoke(Constants.INVOKESPECIAL, type, sig);
+        emit_invoke(Constants.INVOKESPECIAL, type, sig, false);
     }
 
     public void invoke_constructor_this(Signature sig) {
@@ -850,7 +855,7 @@ public class CodeEmitter extends LocalVariablesSorter {
         if (sig.getName().equals(Constants.CONSTRUCTOR_NAME)) {
             invoke_constructor(type, sig);
         } else if (TypeUtils.isStatic(method.getModifiers())) {
-            invoke_static(type, sig);
+            invoke_static(type, sig, TypeUtils.isInterface(classInfo.getModifiers()));
         } else if (TypeUtils.isInterface(classInfo.getModifiers())) {
             invoke_interface(type, sig);
         } else {

--- a/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
+++ b/cglib/src/main/java/net/sf/cglib/core/KeyFactory.java
@@ -246,7 +246,7 @@ abstract public class KeyFactory {
             }
 
             Type[] parameterTypes = TypeUtils.getTypes(newInstance.getParameterTypes());
-            ce.begin_class(Constants.V1_2,
+            ce.begin_class(Constants.V1_8,
                            Constants.ACC_PUBLIC,
                            getClassName(),
                            KEY_FACTORY,

--- a/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
@@ -591,7 +591,7 @@ public class Enhancer extends AbstractClassGenerator
 
         ClassEmitter e = new ClassEmitter(v);
         if (currentData == null) {
-        e.begin_class(Constants.V1_2,
+        e.begin_class(Constants.V1_8,
                       Constants.ACC_PUBLIC,
                       getClassName(),
                       Type.getType(sc),
@@ -600,7 +600,7 @@ public class Enhancer extends AbstractClassGenerator
                        TypeUtils.getTypes(interfaces)),
                       Constants.SOURCE_FILE);
         } else {
-            e.begin_class(Constants.V1_2,
+            e.begin_class(Constants.V1_8,
                     Constants.ACC_PUBLIC,
                     getClassName(),
                     null,

--- a/cglib/src/main/java/net/sf/cglib/proxy/InterfaceMaker.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/InterfaceMaker.java
@@ -100,8 +100,8 @@ public class InterfaceMaker extends AbstractClassGenerator
 
     public void generateClass(ClassVisitor v) throws Exception {
         ClassEmitter ce = new ClassEmitter(v);
-        ce.begin_class(Constants.V1_2,
-                       Constants.ACC_PUBLIC | Constants.ACC_INTERFACE,
+        ce.begin_class(Constants.V1_8,
+                       Constants.ACC_PUBLIC | Constants.ACC_INTERFACE | Constants.ACC_ABSTRACT,
                        getClassName(),
                        null,
                        null,

--- a/cglib/src/main/java/net/sf/cglib/proxy/MixinEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/MixinEmitter.java
@@ -37,7 +37,7 @@ class MixinEmitter extends ClassEmitter {
     public MixinEmitter(ClassVisitor v, String className, Class[] classes, int[] route) {
         super(v);
 
-        begin_class(Constants.V1_2,
+        begin_class(Constants.V1_8,
                     Constants.ACC_PUBLIC,
                     className,
                     MIXIN,

--- a/cglib/src/main/java/net/sf/cglib/reflect/ConstructorDelegate.java
+++ b/cglib/src/main/java/net/sf/cglib/reflect/ConstructorDelegate.java
@@ -92,7 +92,7 @@ abstract public class ConstructorDelegate {
             }
 
             ClassEmitter ce = new ClassEmitter(v);
-            ce.begin_class(Constants.V1_2,
+            ce.begin_class(Constants.V1_8,
                            Constants.ACC_PUBLIC,
                            getClassName(),
                            CONSTRUCTOR_DELEGATE,

--- a/cglib/src/main/java/net/sf/cglib/reflect/FastClassEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/reflect/FastClassEmitter.java
@@ -53,7 +53,7 @@ class FastClassEmitter extends ClassEmitter {
         super(v);
 
         Type base = Type.getType(type);
-        begin_class(Constants.V1_2, Constants.ACC_PUBLIC, className, FAST_CLASS, null, Constants.SOURCE_FILE);
+        begin_class(Constants.V1_8, Constants.ACC_PUBLIC, className, FAST_CLASS, null, Constants.SOURCE_FILE);
 
         // constructor
         CodeEmitter e = begin_method(Constants.ACC_PUBLIC, CSTRUCT_CLASS, null);

--- a/cglib/src/main/java/net/sf/cglib/reflect/MethodDelegate.java
+++ b/cglib/src/main/java/net/sf/cglib/reflect/MethodDelegate.java
@@ -218,7 +218,7 @@ abstract public class MethodDelegate {
 
             ClassEmitter ce = new ClassEmitter(v);
             CodeEmitter e;
-            ce.begin_class(Constants.V1_2,
+            ce.begin_class(Constants.V1_8,
                            Constants.ACC_PUBLIC,
                            getClassName(),
                            METHOD_DELEGATE,

--- a/cglib/src/main/java/net/sf/cglib/reflect/MulticastDelegate.java
+++ b/cglib/src/main/java/net/sf/cglib/reflect/MulticastDelegate.java
@@ -102,7 +102,7 @@ abstract public class MulticastDelegate implements Cloneable {
             final MethodInfo method = ReflectUtils.getMethodInfo(ReflectUtils.findInterfaceMethod(iface));
 
             ClassEmitter ce = new ClassEmitter(cv);
-            ce.begin_class(Constants.V1_2,
+            ce.begin_class(Constants.V1_8,
                            Constants.ACC_PUBLIC,
                            getClassName(),
                            MULTICAST_DELEGATE,

--- a/cglib/src/main/java/net/sf/cglib/util/ParallelSorterEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/util/ParallelSorterEmitter.java
@@ -33,7 +33,7 @@ class ParallelSorterEmitter extends ClassEmitter {
 
     public ParallelSorterEmitter(ClassVisitor v, String className, Object[] arrays) {
         super(v);
-        begin_class(Constants.V1_2, Constants.ACC_PUBLIC, className, PARALLEL_SORTER, null, Constants.SOURCE_FILE);
+        begin_class(Constants.V1_8, Constants.ACC_PUBLIC, className, PARALLEL_SORTER, null, Constants.SOURCE_FILE);
         EmitUtils.null_constructor(this);
         EmitUtils.factory_method(this, NEW_INSTANCE);
         generateConstructor(arrays);

--- a/cglib/src/main/java/net/sf/cglib/util/StringSwitcher.java
+++ b/cglib/src/main/java/net/sf/cglib/util/StringSwitcher.java
@@ -118,7 +118,7 @@ abstract public class StringSwitcher {
 
         public void generateClass(ClassVisitor v) throws Exception {
             ClassEmitter ce = new ClassEmitter(v);
-            ce.begin_class(Constants.V1_2,
+            ce.begin_class(Constants.V1_8,
                            Constants.ACC_PUBLIC,
                            getClassName(),
                            STRING_SWITCHER,


### PR DESCRIPTION
This is necessary for https://github.com/cglib/cglib/commit/380ef56d63756e0a26cce2f8016b3d949482907d to work properly on all JDKs