### PR TITLE
Update pom.xml to use the SPDIX license identifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <licenses>
         <license>
-            <name>ASF 2.0</name>
+            <name>Apache-2.0</name>
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
Update pom.xml to use the SPDIX license indentifier for Apache 2 license.

The benefit of this change is that build automation tools on the market will automatically recognize CGLIB as being an Apache 2.0 licensed library. This is helpful for those organizations that only allow open source libraries licensed under specific whitelisted licenses to be used.

Fixes #168 