### PR TITLE
Add null check in Enhancer

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
@@ -287,8 +287,8 @@ public class Enhancer extends AbstractClassGenerator
      * @param callbackTypes the array of callback types
      */
     public void setCallbackTypes(Class[] callbackTypes) {
-        if (callbackTypes != null && callbackTypes.length == 0) {
-            throw new IllegalArgumentException("Array cannot be empty");
+        if (callbackTypes == null || callbackTypes.length == 0) {
+            throw new IllegalArgumentException("Array cannot be null or empty");
         }
         this.callbackTypes = CallbackInfo.determineTypes(callbackTypes);
     }


### PR DESCRIPTION
In fact , `callbackTypes` var can neither be empty nor null.
If `callbackTypes` var is null, `determineTypes` method will produce a NEP.
So, suggest add a check about null.
Looking forward to your feedback.
