### PR TITLE
Remove an unused wildcard import

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/reflect/MethodDelegate.java
+++ b/cglib/src/main/java/net/sf/cglib/reflect/MethodDelegate.java
@@ -17,7 +17,6 @@ package net.sf.cglib.reflect;
 
 import java.lang.reflect.*;
 import java.security.ProtectionDomain;
-import net.sf.cglib.*;
 import net.sf.cglib.core.*;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Type;


### PR DESCRIPTION
This fixes a build error when no classes in `net.sf.cglib` are on the
classpath.