### PR TITLE
Fix malformed HTML in Javadoc

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/GeneratorStrategy.java
+++ b/cglib/src/main/java/net/sf/cglib/core/GeneratorStrategy.java
@@ -16,7 +16,7 @@
 package net.sf.cglib.core;
 
 /**
- * The <code>GeneratorStrategy</code. is responsible for taking a
+ * The <code>GeneratorStrategy</code> is responsible for taking a
  * {@link ClassGenerator} and producing a byte array containing the
  * data for the generated <code>Class</code>.  By providing your
  * own strategy you may examine or modify the generated class before

--- a/cglib/src/main/java/net/sf/cglib/reflect/MethodDelegate.java
+++ b/cglib/src/main/java/net/sf/cglib/reflect/MethodDelegate.java
@@ -64,7 +64,7 @@ import org.objectweb.asm.Type;
  *       }
  *
  *       public int alternateMain( String[] args ) {
- *           for (int i = 0; i < args.length; i++) {
+ *           for (int i = 0; i &lt; args.length; i++) {
  *               System.out.println( args[i] );
  *           }
  *           return args.length;


### PR DESCRIPTION
This PR fixes malformed HTML in Javadoc by applying https://github.com/spring-projects/spring-framework/commit/d6f73994c2385c98b9d70853f684866861364d80 that has been done in the fork in the Spring Framework.