### PR TITLE
Migrate from deprecated boxed primitive constructors

### DIFF
--- a/cglib/src/main/java/net/sf/cglib/core/CodeEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/core/CodeEmitter.java
@@ -297,7 +297,7 @@ public class CodeEmitter extends LocalVariablesSorter {
 
     public void push(int i) {
         if (i < -1) {
-            mv.visitLdcInsn(new Integer(i));
+            mv.visitLdcInsn(Integer.valueOf(i));
         } else if (i <= 5) {
             mv.visitInsn(TypeUtils.ICONST(i));
         } else if (i <= Byte.MAX_VALUE) {
@@ -305,7 +305,7 @@ public class CodeEmitter extends LocalVariablesSorter {
         } else if (i <= Short.MAX_VALUE) {
             mv.visitIntInsn(Constants.SIPUSH, i);
         } else {
-            mv.visitLdcInsn(new Integer(i));
+            mv.visitLdcInsn(Integer.valueOf(i));
         }
     }
     
@@ -313,7 +313,7 @@ public class CodeEmitter extends LocalVariablesSorter {
         if (value == 0L || value == 1L) {
             mv.visitInsn(TypeUtils.LCONST(value));
         } else {
-            mv.visitLdcInsn(new Long(value));
+            mv.visitLdcInsn(Long.valueOf(value));
         }
     }
     
@@ -321,14 +321,14 @@ public class CodeEmitter extends LocalVariablesSorter {
         if (value == 0f || value == 1f || value == 2f) {
             mv.visitInsn(TypeUtils.FCONST(value));
         } else {
-            mv.visitLdcInsn(new Float(value));
+            mv.visitLdcInsn(Float.valueOf(value));
         }
     }
     public void push(double value) {
         if (value == 0d || value == 1d) {
             mv.visitInsn(TypeUtils.DCONST(value));
         } else {
-            mv.visitLdcInsn(new Double(value));
+            mv.visitLdcInsn(Double.valueOf(value));
         }
     }
     

--- a/cglib/src/main/java/net/sf/cglib/core/CollectionUtils.java
+++ b/cglib/src/main/java/net/sf/cglib/core/CollectionUtils.java
@@ -68,7 +68,7 @@ public class CollectionUtils {
         Map indexes = new HashMap();
         int index = 0;
         for (Iterator it = list.iterator(); it.hasNext();) {
-            indexes.put(it.next(), new Integer(index++));
+            indexes.put(it.next(), Integer.valueOf(index++));
         }
         return indexes;
     }

--- a/cglib/src/main/java/net/sf/cglib/core/EmitUtils.java
+++ b/cglib/src/main/java/net/sf/cglib/core/EmitUtils.java
@@ -193,14 +193,14 @@ public class EmitUtils {
         final Label end = e.make_label();
         final Map buckets = CollectionUtils.bucket(Arrays.asList(strings), new Transformer() {
             public Object transform(Object value) {
-                return new Integer(((String)value).length());
+                return ((String)value).length();
             }
         });
         e.dup();
         e.invoke_virtual(Constants.TYPE_STRING, STRING_LENGTH);
         e.process_switch(getSwitchKeys(buckets), new ProcessSwitchCallback() {
                 public void processCase(int key, Label ignore_end) throws Exception {
-                    List bucket = (List)buckets.get(new Integer(key));
+                    List bucket = (List)buckets.get(Integer.valueOf(key));
                     stringSwitchHelper(e, bucket, callback, def, end, 0);
                 }
                 public void processDefault() {
@@ -222,7 +222,7 @@ public class EmitUtils {
         final int len = ((String)strings.get(0)).length();
         final Map buckets = CollectionUtils.bucket(strings, new Transformer() {
             public Object transform(Object value) {
-                return new Integer(((String)value).charAt(index));
+                return (int) ((String)value).charAt(index);
             }
         });
         e.dup();
@@ -230,7 +230,7 @@ public class EmitUtils {
         e.invoke_virtual(Constants.TYPE_STRING, STRING_CHAR_AT);
         e.process_switch(getSwitchKeys(buckets), new ProcessSwitchCallback() {
                 public void processCase(int key, Label ignore_end) throws Exception {
-                    List bucket = (List)buckets.get(new Integer(key));
+                    List bucket = (List)buckets.get(Integer.valueOf(key));
                     if (index + 1 == len) {
                         e.pop();
                         callback.processCase(bucket.get(0), end);
@@ -260,7 +260,7 @@ public class EmitUtils {
                                            final boolean skipEquals) throws Exception {
         final Map buckets = CollectionUtils.bucket(Arrays.asList(strings), new Transformer() {
             public Object transform(Object value) {
-                return new Integer(value.hashCode());
+                return value.hashCode();
             }
         });
         final Label def = e.make_label();
@@ -269,7 +269,7 @@ public class EmitUtils {
         e.invoke_virtual(Constants.TYPE_OBJECT, HASH_CODE);
         e.process_switch(getSwitchKeys(buckets), new ProcessSwitchCallback() {
             public void processCase(int key, Label ignore_end) throws Exception {
-                List bucket = (List)buckets.get(new Integer(key));
+                List bucket = (List)buckets.get(Integer.valueOf(key));
                 Label next = null;
                 if (skipEquals && bucket.size() == 1) {
                     if (skipEquals)
@@ -781,14 +781,14 @@ public class EmitUtils {
                                            final Label end) throws Exception {
         final Map buckets = CollectionUtils.bucket(members, new Transformer() {
             public Object transform(Object value) {
-                return new Integer(typer.getParameterTypes((MethodInfo)value).length);
+                return typer.getParameterTypes((MethodInfo)value).length;
             }
         });
         e.dup();
         e.arraylength();
         e.process_switch(EmitUtils.getSwitchKeys(buckets), new ProcessSwitchCallback() {
             public void processCase(int key, Label dontUseEnd) throws Exception {
-                List bucket = (List)buckets.get(new Integer(key));
+                List bucket = (List)buckets.get(Integer.valueOf(key));
                 member_helper_type(e, bucket, callback, typer, def, end, new BitSet());
             }
             public void processDefault() throws Exception {

--- a/cglib/src/main/java/net/sf/cglib/core/ReflectUtils.java
+++ b/cglib/src/main/java/net/sf/cglib/core/ReflectUtils.java
@@ -455,10 +455,10 @@ public class ReflectUtils {
     public static Class defineClass(String className, byte[] b, ClassLoader loader, ProtectionDomain protectionDomain) throws Exception {
         Class c;
         if (DEFINE_CLASS != null) {
-            Object[] args = new Object[]{className, b, new Integer(0), new Integer(b.length), protectionDomain };
+            Object[] args = new Object[]{className, b, 0, b.length, protectionDomain };
             c = (Class)DEFINE_CLASS.invoke(loader, args);
         } else if (DEFINE_CLASS_UNSAFE != null) {
-            Object[] args = new Object[]{className, b, new Integer(0), new Integer(b.length), loader, protectionDomain };
+            Object[] args = new Object[]{className, b, 0, b.length, loader, protectionDomain };
             c = (Class)DEFINE_CLASS_UNSAFE.invoke(UNSAFE, args);
         } else {
             throw new CodeGenerationException(THROWABLE);

--- a/cglib/src/main/java/net/sf/cglib/proxy/CallbackHelper.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/CallbackHelper.java
@@ -45,7 +45,7 @@ implements CallbackFilter
                 throw new IllegalStateException("getCallback must return a Callback or a Class consistently for every Method");
             Integer index = (Integer)indexes.get(callback);
             if (index == null) {
-                index = new Integer(callbacks.size());
+                index = callbacks.size();
                 indexes.put(callback, index);
             }
             methodMap.put(method, index);

--- a/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/Enhancer.java
@@ -1109,8 +1109,8 @@ public class Enhancer extends AbstractClassGenerator
             if (index >= callbackTypes.length) {
                 throw new IllegalArgumentException("Callback filter returned an index that is too large: " + index);
             }
-            originalModifiers.put(method, new Integer((actualMethod != null) ? actualMethod.getModifiers() : method.getModifiers()));
-            indexes.put(method, new Integer(index));
+            originalModifiers.put(method, Integer.valueOf((actualMethod != null) ? actualMethod.getModifiers() : method.getModifiers()));
+            indexes.put(method, Integer.valueOf(index));
             List group = (List)groups.get(generators[index]);
             if (group == null) {
                 groups.put(generators[index], group = new ArrayList(methods.size()));

--- a/cglib/src/main/java/net/sf/cglib/proxy/LazyLoaderGenerator.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/LazyLoaderGenerator.java
@@ -36,7 +36,7 @@ class LazyLoaderGenerator implements CallbackGenerator {
                 // ignore protected methods
             } else {
                 int index = context.getIndex(method);
-                indexes.add(new Integer(index));
+                indexes.add(Integer.valueOf(index));
                 CodeEmitter e = context.beginMethod(ce, method);
                 e.load_this();
                 e.dup();

--- a/cglib/src/main/java/net/sf/cglib/proxy/Mixin.java
+++ b/cglib/src/main/java/net/sf/cglib/proxy/Mixin.java
@@ -224,7 +224,7 @@ abstract public class Mixin {
                 for (Iterator it = collect.iterator(); it.hasNext();) {
                     Class iface = (Class)it.next();
                     if (!map.containsKey(iface)) {
-                        map.put(iface, new Integer(i));
+                        map.put(iface, Integer.valueOf(i));
                     }
                 }
             }

--- a/cglib/src/main/java/net/sf/cglib/reflect/FastClassEmitter.java
+++ b/cglib/src/main/java/net/sf/cglib/reflect/FastClassEmitter.java
@@ -201,7 +201,7 @@ class FastClassEmitter extends ClassEmitter {
             this.e = e;
             int index = 0;
             for (Iterator it = methods.iterator(); it.hasNext();) {
-                indexes.put(it.next(), new Integer(index++));
+                indexes.put(it.next(), Integer.valueOf(index++));
             }
         }
             


### PR DESCRIPTION
to their replacements. E.g., `new Integer(...)` becomes `Integer.valueOf(...)`.